### PR TITLE
docs: governance rationale, install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,11 @@ dispatch, merge conflict resolution, and CI verification.
 
 ## Install
 
+Add the marketplace, then install:
+
 ```
-/plugin install symphonize
+/plugin marketplace add repentsinner/symphonize
+/plugin install symphonize@repentsinner-symphonize
 ```
 
 Or from source during development:


### PR DESCRIPTION
## Summary
- Adds "Why in-repo?" rationale for governance files over GitHub Issues/Discussions
- Fixes install instructions with marketplace add + repo name

## Test plan
- [ ] Verify README renders correctly on GitHub