### PR TITLE
fix: switch release workflows to GitHub App token

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -10,10 +10,16 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'github-actions[bot]' && contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.RELEASE_PLEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace `RELEASE_PLEASE_PAT` with GitHub App token via `actions/create-github-app-token@v1`
- Use app token in both release-please and auto-merge workflows
- Simplify auto-merge condition to label-only (`autorelease: pending`)

Requires repo secrets: `RELEASE_BOT_APP_ID`, `RELEASE_BOT_PRIVATE_KEY`

## Test plan
- [ ] Merge this PR → release-please should create a release PR using the app identity
- [ ] Release PR should trigger CI (app token, not GITHUB_TOKEN)
- [ ] Auto-merge should pick up the release PR via label