### PR TITLE
fix: use pull_request_target for auto-merge trigger

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,7 +1,7 @@
 name: Auto-merge Release PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 
 permissions:


### PR DESCRIPTION
## Summary
- Switch auto-merge trigger from `pull_request` to `pull_request_target`
- `pull_request` events don't fire for PRs created by the same GitHub App token (loop prevention)
- `pull_request_target` fires for all PRs including those from apps

## Test plan
- [ ] Merge this → next release-please PR should trigger auto-merge