### PR TITLE
docs: list runtime dependencies in prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ claude --plugin-dir /path/to/symphonize
 
 ### Prerequisites
 
+- `git`, `gh` (authenticated), and `npx` (Node.js) on `PATH`
 - A project with `SPEC.md` and `ROADMAP.md` following the conventions
-  in your `CLAUDE.md`
+  in your `CLAUDE.md` (or run `/symphonize:init` to scaffold them)
 - [ralph-loop](https://github.com/anthropics/claude-plugins-public/tree/main/plugins/ralph-loop)
   plugin (for unattended `/orchestrate` mode)
-- `gh` CLI authenticated
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add `git`, `gh`, and `npx` as explicit prerequisites
- Note that `/symphonize:init` can scaffold governance files

## Test plan
- [ ] README renders correctly