### PR TITLE
fix: run clean --lite before starting orchestrate loop

### DIFF
--- a/commands/orchestrate.md
+++ b/commands/orchestrate.md
@@ -1,7 +1,10 @@
 ---
 description: Start ralph-loop to work through ROADMAP.md
 ---
-Run `/ralph-loop:ralph-loop` with the following arguments:
+Run `/symphonize:clean --lite` to ensure local state is clean before
+starting the loop.
+
+Then run `/ralph-loop:ralph-loop` with the following arguments:
 
 ```
 "Run /symphonize:next to execute the next unblocked workstreams in the active roadmap section (depth-first). When /symphonize:next reports all unblocked workstreams are attempted, output <promise>BLOCKED ON REVIEW</promise>." --completion-promise "BLOCKED ON REVIEW"


### PR DESCRIPTION
## Summary
- Run `/symphonize:clean --lite` at the start of `/orchestrate` to ensure local state is clean before the first `/next` call

## Test plan
- [ ] Verify orchestrate runs clean --lite before starting ralph-loop