### PR TITLE
feat: add CONVENTIONS.md with self-contained governance rules

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,165 @@
+# Conventions
+
+Rules that symphonize enforces on projects using its governance loop.
+
+## Spec format
+
+SPEC.md is declarative: it describes the desired end state of the system,
+not the steps to reach it. Read a spec as "the system is X" — not "do X."
+After implementation, every statement in the spec should still read as a
+true description of the running system.
+
+Rules:
+
+- State the problem first: what fails or is missing for the end user.
+- Write declaratively. Describe what the system does, not what to change.
+  "The API returns 404 for unknown IDs" — not "Add a 404 response for
+  unknown IDs."
+- Each section shall answer "why" — what decision was made and what
+  constraint drove it. If the rationale is missing, the section is
+  incomplete.
+- When wrapping or integrating an external system, reference it — don't
+  re-spec it. Document only deviations, scope boundaries, and decisions
+  specific to this project.
+- Write each criterion as observable behavior: "the system shall…" or
+  "when X, the system shall Y." Model after EARS for structure, but
+  don't force every line into rigid templates.
+- Criteria must remain valid after implementation. If a criterion becomes
+  nonsensical once the work is complete, it belongs in a commit message,
+  not a spec.
+- No implementation details. The spec survives if you swap the underlying
+  mechanism.
+- The spec shall be sufficient to reconstruct the project's design intent.
+  A reader with no conversation history should understand what was built
+  and why.
+- Each `##` section shall carry a bare status line immediately after the
+  heading (before body content):
+  `*Status: not started | in progress | complete*`
+  No additional detail (PR numbers, dates, descriptions) on the status
+  line. Update status when work begins and when it merges. CI validates
+  placement and values via governance-lint.
+- Headings use slug-style `##` (unnumbered). `## Plugin commands` not
+  `## 1. Plugin commands`.
+
+Reference: Alistair Mavin et al., "EARS (Easy Approach to Requirements
+Syntax)" (2009).
+
+### Spec compression
+
+A spec section serves two audiences at different times. Before
+implementation, it guides the developer — the more detail, the fewer
+ambiguities. After implementation, it serves as a verifiable description
+of the running system and a record of design rationale.
+
+When a spec section reaches `complete`, compress it. The section shifts
+from guiding implementation to documenting the running system.
+
+**Retain**:
+
+- Design rationale ("Why X"): constraints, tradeoffs, rejected
+  alternatives. Expensive to reconstruct; prevents re-litigation.
+- Observable behavior: verifiable statements a reviewer can check
+  against the running system.
+- State machines and transition tables: compact, high-signal.
+- Cross-references to other spec sections.
+
+**Remove**:
+
+- Protocol byte values, command tables, wire formats: reference material
+  for the underlying protocol, not spec. Replace with a pointer to the
+  protocol's own documentation.
+- Algorithm pseudocode and step-by-step implementation detail: the code
+  is the source of truth for *how*. The spec owns *what* and *why*.
+- Enumerated edge cases obvious from the implementation or tests.
+- "Shall" language that restates what the code does without adding
+  rationale.
+
+**Heuristic**: cover a paragraph with your thumb. If the section's
+design intent survives, cut it. If the *why* disappears, keep it.
+
+## Roadmap format
+
+ROADMAP.md is imperative: it describes the work remaining to close
+the gap between current state and the spec's target state.
+Read a roadmap as "we need to do X" — not "the system is X."
+The roadmap is a work queue, not a history log. It should stay small.
+
+Rules:
+
+- Derive from SPEC.md. Every roadmap item traces to a spec gap.
+- Un-numbered `##` sections in build-dependency order. Earlier sections
+  validate assumptions that later sections depend on.
+- New work enters at the tail. Completed work leaves from the head.
+- When a section or workstream completes, delete it from the roadmap.
+  Conventional commit messages feed release-please, which records the
+  history in CHANGELOG.md. The roadmap does not duplicate that record.
+  Presence in the roadmap means the work is not done.
+- Workstreams are `### §road:slug` headings under each section.
+  Slugs are lowercase, hyphenated, grep-friendly
+  (e.g. `§road:delete-noise-tests`, `§road:extract-protocol`).
+- Size each workstream to fit one agent session (~200k tokens).
+  If a workstream is too large, split it.
+- Blocked workstreams stay under the section they belong to, annotated
+  inline ("Blocked — reason. Unblocked when condition.").
+- Dependencies between workstreams are stated inline
+  ("Depends on §road:extract-core").
+- Update the roadmap when work starts and when it finishes. Stale
+  entries erode trust in the document.
+- Lives at repo root alongside SPEC.md.
+
+Reference: CNCF open source roadmap best practices;
+Mozilla Open Science "Intro to Roadmapping."
+
+## Changelog format
+
+CHANGELOG.md records what shipped. Follows Keep a Changelog
+(<https://keepachangelog.com/en/1.1.0/>).
+
+Rules:
+
+- Lives at repo root.
+- Always has an `## [Unreleased]` section at the top.
+- Groups: Added, Changed, Deprecated, Removed, Fixed, Security.
+- Dates in YYYY-MM-DD. Versions in reverse chronological order.
+- Automation via release-please is preferred where available. Manual
+  maintenance is acceptable until automation is configured.
+
+## Commit conventions
+
+- One logical change per commit. If a commit message needs "and," split
+  it into two commits.
+- Use conventional commits: `<type>(<scope>): <description>`
+- Types: feat fix docs style refactor perf test build ci chore revert
+- Semver mapping: feat = minor, fix = patch, BREAKING CHANGE footer
+  or `!` = major.
+
+## Branching
+
+- Always work on a feature branch. Never commit directly to main.
+- One logical unit of work per branch. A workstream, a bug fix, a
+  feature — not a quarter's worth of refactoring.
+- Branch naming: `<type>/<short-description>` matching the commit scope.
+  Examples: `refactor/decouple-domain-logging`, `fix/parser-null-check`,
+  `feat/buffer-aware-execution`.
+- Create from `origin/main`. Merge or abandon within the session when
+  possible. Long-lived branches accumulate merge pain.
+
+## Quality gate
+
+A branch is not ready to merge until analysis and tests pass with
+zero failures and zero warnings from new code.
+
+Rules:
+
+- Never merge with failing tests. "Pre-existing" is not an excuse —
+  fix it or delete it in the same branch.
+- Never skip a failing test to unblock a merge. A flaky, broken, or
+  vacuous test is a defect. Fix or remove it with a commit explaining
+  why.
+- Warnings from new or modified code must be resolved. Warnings from
+  untouched code may be deferred to a lint-hardening workstream, but
+  document them.
+- Every "known failure" that ships becomes invisible within a session.
+  Agents normalize it and stop investigating. Within two batches the
+  failure count drifts and real regressions hide behind the noise floor.
+  Zero is the only sustainable baseline.


### PR DESCRIPTION
## Summary

- Extracts governance conventions from the author's CLAUDE.md into a self-contained `CONVENTIONS.md` at repo root
- Covers spec format (including compression rules), roadmap format, changelog format, commit conventions, branching rules, and quality gate
- Uses slug-style `##` headings per SPEC.md §6 requirements
- Adapted to be plugin conventions that symphonize enforces, not personal developer rules

## Test plan

- [x] markdownlint passes on all governance files
- [ ] CI governance-lint workflow passes
- [ ] Review content matches SPEC.md §6 requirements for CONVENTIONS.md sections