### PR TITLE
feat: add Vale prose linter with IEEE modal verb rules

### DIFF
--- a/.github/workflows/governance-lint.yml
+++ b/.github/workflows/governance-lint.yml
@@ -17,6 +17,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Run Vale prose linter
+        if: hashFiles('.vale.ini') != ''
+        run: |
+          wget -qO- https://github.com/errata-ai/vale/releases/download/v3.13.1/vale_3.13.1_Linux_64-bit.tar.gz | tar xz -C /usr/local/bin vale
+          vale SPEC.md
+          if [ -f REQUIREMENTS.md ]; then
+            vale REQUIREMENTS.md
+          fi
+
       - uses: DavidAnson/markdownlint-cli2-action@v19
         with:
           globs: |

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,8 @@
+StylesPath = styles
+MinAlertLevel = warning
+
+[SPEC.md]
+BasedOnStyles = Requirements
+
+[REQUIREMENTS.md]
+BasedOnStyles = Requirements

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,48 +1,11 @@
 # symphonize — Roadmap
 
-## Governance consistency
-
-Fix inconsistencies found in the audit. All workstreams are
-independent and unblocked.
-
-### §road:fix-init-numbered-headings
-Fix init.md scaffolding template: replace `## 1. <first section>`
-with slug-style `## <first section> §spec:<slug>` to match
-CONVENTIONS.md format rules. Add `§spec:` suffix and status line
-to the SPEC.md skeleton. Add REQUIREMENTS.md skeleton to the
-scaffolded files list.
-
-### §road:document-requirements-sections
-Document the standard REQUIREMENTS.md sections (problem statement,
-success criteria, user stories, constraints, priorities) in
-CONVENTIONS.md. Currently only defined in discover.md — should
-live in conventions so any tool can produce conformant output.
-
-### §road:lint-scope-docs
-Document in lint.md that the plugin command runs markdownlint
-only, while governance-lint.yml also validates status lines,
-slug formats, cross-references, and (future) prose quality.
-Users should know which checks they get locally vs. in CI.
-
-### §road:markdownlint-glob-expansion
-Add REQUIREMENTS.md and CHANGELOG.md to markdownlint globs in
-governance-lint.yml. Currently only SPEC.md, ROADMAP.md, and
-README.md are linted for markdown formatting.
-
 ## Prose linting
 
 Add Vale-based prose quality checks to the governance-lint
 workflow.
 
-### §road:vale-integration
-Add Vale to governance-lint.yml. Create a `Requirements` style
-with rules for IEEE modal verbs (flag deprecated "must"/"will",
-require "shall" for mandatory requirements), passive voice in
-requirements, and filler phrases. Run against SPEC.md and
-REQUIREMENTS.md.
-
 ### §road:init-scaffolds-vale
 Update init.md to scaffold `.vale.ini` and
 `styles/Requirements/` with the modal verb rules. Projects opt
-in to prose linting by having these files. Depends on
-§road:vale-integration.
+in to prose linting by having these files.

--- a/SPEC.md
+++ b/SPEC.md
@@ -147,13 +147,13 @@ translation from requirements to spec is where design decisions
 happen — that boundary should be explicit.
 
 ## Prose linting §spec:prose-linting
-*Status: not started*
+*Status: in progress*
 
 The governance-lint workflow validates structure (markdownlint) and
 cross-references (slug resolution), but not prose quality. SPEC.md
 and REQUIREMENTS.md use IEEE modal verbs — "shall" for mandatory
 requirements, "should" for recommendations, "may" for permission.
-"Must" and "will" are deprecated per IEEE SA Standards Style Manual.
+`Must` and `will` are deprecated per IEEE SA Standards Style Manual.
 
 Vale (<https://vale.sh>) enforces prose rules via custom YAML
 styles. A `Requirements` style checks modal verb compliance, flags
@@ -167,8 +167,8 @@ by adding `.vale.ini` and a `styles/` directory via
 
 **Why prose linting:** agents generate requirements and spec text
 that drifts toward vague, passive, non-testable language.
-Mechanical enforcement catches "the system will..." (deprecated)
-and "it should be noted that..." (filler) before review.
+Mechanical enforcement catches `the system will...` (deprecated)
+and `it should be noted that...` (filler) before review.
 
 ## Requirements frameworks §spec:requirements-frameworks
 *Status: complete*

--- a/styles/Requirements/FillerPhrases.yml
+++ b/styles/Requirements/FillerPhrases.yml
@@ -1,0 +1,12 @@
+extends: existence
+message: "Filler phrase '%s' — cut it."
+ignorecase: true
+level: warning
+scope: sentence
+tokens:
+  - 'it should be noted that'
+  - 'in order to'
+  - 'due to the fact that'
+  - 'it is important to note'
+  - 'at this point in time'
+  - 'for the purpose of'

--- a/styles/Requirements/MustDeprecated.yml
+++ b/styles/Requirements/MustDeprecated.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "'%s' is deprecated by IEEE. Use 'shall' for mandatory requirements."
+ignorecase: true
+level: error
+scope: sentence
+tokens:
+  - '\bmust\b'

--- a/styles/Requirements/WillDeprecated.yml
+++ b/styles/Requirements/WillDeprecated.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "'%s' is deprecated by IEEE for requirements. Use 'shall' for mandatory, 'should' for recommended."
+ignorecase: true
+level: warning
+scope: sentence
+tokens:
+  - '\bwill\b'


### PR DESCRIPTION
## Summary
- Add Vale prose linter to `governance-lint.yml` with a `Requirements` style enforcing IEEE modal verb conventions (`shall`/`should`/`may`), flagging deprecated `must`/`will`, and catching filler phrases
- Create `.vale.ini` and `styles/Requirements/` with three rules: `MustDeprecated` (error), `WillDeprecated` (warning), `FillerPhrases` (warning)
- Fix SPEC.md prose-linting section to use code spans for example terms that would trigger the new rules
- Remove completed governance-consistency workstreams from ROADMAP.md; update §spec:prose-linting status to `in progress`

## Test plan
- [ ] CI governance-lint job passes (Vale + markdownlint + all structural checks)
- [ ] `vale SPEC.md` returns zero errors locally
- [ ] Governance-lint step skips Vale when `.vale.ini` is absent (opt-in behavior)