### PR TITLE
docs(plan): product-type-agnostic discover command

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,16 @@
 # symphonize — Roadmap
 
+## Product-type-agnostic discovery
+
+Make `/symphonize:discover` work for any product type, not just
+consumer apps. Implements §spec:product-type-agnostic-discovery.
+
+### §road:product-neutral-discover
+Update `commands/discover.md`: replace "app" with product-neutral
+terms, add early product-type classifier question in Phase 1,
+generalize Deep Dive table headings (Usage & Workflow, Capabilities,
+broaden Data & Content), and reframe onboarding/abandonment
+questions to cover libraries, platforms, CLI tools, and hardware.
 ## Prose linting
 
 Add Vale-based prose quality checks to the governance-lint

--- a/SPEC.md
+++ b/SPEC.md
@@ -190,6 +190,42 @@ richer problem statements and priority rationale without imposing
 structured output forms. CONVENTIONS.md documents both taxonomies
 as interviewer references.
 
+## Product-type-agnostic discovery §spec:product-type-agnostic-discovery
+*Status: not started*
+
+The `/symphonize:discover` command assumes consumer-facing applications.
+Terms like "app," "user journey," and "onboarding" exclude libraries,
+SDKs, platforms, CLI tools, hardware devices, and internal components.
+Users building these product types encounter questions that don't apply
+and miss questions that do.
+
+The discover command uses product-neutral language throughout. Specific
+changes:
+
+- **Early classifier.** Phase 1 opens with "What kind of thing is
+  this?" (application, library/SDK, platform/service, CLI tool,
+  hardware device, other). The answer gates which subsequent prompts
+  are relevant — a library doesn't need onboarding-discovery
+  questions; hardware doesn't need integrations the same way.
+- **Terminology.** "App" becomes "product" or is dropped where the
+  sentence works without a noun. "User journey" becomes "workflow"
+  or "usage scenario." "Abandon your app" becomes "stop using this
+  or switch to an alternative." "Discovering and onboarding" becomes
+  "first encounter this, and what does getting started look like."
+- **Deep Dive table.** "User Experience" becomes "Usage & Workflow"
+  (covers CLI ergonomics, API surface, operator runbooks, physical
+  interaction). "Core Features" becomes "Capabilities." "Data &
+  Content" broadens to include state and signals for
+  hardware/embedded contexts.
+- **Argument hint.** `[app idea or problem area]` becomes
+  `[product idea or problem area]`.
+
+**Why:** symphonize targets any software product, not just consumer
+apps. Narrow language biases the interview toward GUI applications
+and produces requirements that miss concerns specific to other
+product types (API ergonomics, operator workflows, physical
+constraints).
+
 ## Governance consistency §spec:governance-consistency
 *Status: in progress*
 


### PR DESCRIPTION
## Summary
- Adds `§spec:product-type-agnostic-discovery` spec section describing how the discover command generalizes beyond consumer apps to cover libraries, SDKs, platforms, CLI tools, and hardware
- Adds `§road:product-neutral-discover` workstream for the implementation changes to `commands/discover.md`

## Changes
- **SPEC.md**: New section with terminology swaps, early product-type classifier, and Deep Dive table generalizations
- **ROADMAP.md**: New "Product-type-agnostic discovery" section with one workstream

## Test plan
- [ ] Review spec section for completeness — does it cover the product types you care about?
- [ ] Review roadmap workstream sizing — one session should suffice for the discover.md edits
- [ ] Verify governance-lint passes on the updated files