### PR TITLE
fix(ci): replace Vale wget with vale-cli/vale-action

### DIFF
--- a/.github/workflows/governance-lint.yml
+++ b/.github/workflows/governance-lint.yml
@@ -19,12 +19,9 @@ jobs:
 
       - name: Run Vale prose linter
         if: hashFiles('.vale.ini') != ''
-        run: |
-          wget -qO- https://github.com/errata-ai/vale/releases/download/v3.13.1/vale_3.13.1_Linux_64-bit.tar.gz | tar xz -C /usr/local/bin vale
-          vale SPEC.md
-          if [ -f REQUIREMENTS.md ]; then
-            vale REQUIREMENTS.md
-          fi
+        uses: vale-cli/vale-action@v2
+        with:
+          fail_on_error: true
 
       - uses: DavidAnson/markdownlint-cli2-action@v19
         with:


### PR DESCRIPTION
## Summary

- Replaces manual `wget` + `tar` Vale installation with the official `vale-cli/vale-action@v2` GitHub Action
- Fixes stale download URL (`errata-ai/vale` repo moved to `vale-cli/vale`) and pinned version (v3.13.1 → action manages its own version)
- Action reports errors as GitHub annotations, matching the markdownlint-cli2-action pattern

## Test plan

- [ ] CI runs Vale step successfully on this PR
- [ ] Vale errors surface as GitHub annotations