### PR TITLE
feat: batch — product-neutral discovery interview

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,16 +1,5 @@
 # symphonize — Roadmap
 
-## Product-type-agnostic discovery
-
-Make `/symphonize:discover` work for any product type, not just
-consumer apps. Implements §spec:product-type-agnostic-discovery.
-
-### §road:product-neutral-discover
-Update `commands/discover.md`: replace "app" with product-neutral
-terms, add early product-type classifier question in Phase 1,
-generalize Deep Dive table headings (Usage & Workflow, Capabilities,
-broaden Data & Content), and reframe onboarding/abandonment
-questions to cover libraries, platforms, CLI tools, and hardware.
 ## Prose linting
 
 Add Vale-based prose quality checks to the governance-lint

--- a/SPEC.md
+++ b/SPEC.md
@@ -191,34 +191,12 @@ structured output forms. CONVENTIONS.md documents both taxonomies
 as interviewer references.
 
 ## Product-type-agnostic discovery §spec:product-type-agnostic-discovery
-*Status: not started*
+*Status: complete*
 
-The `/symphonize:discover` command assumes consumer-facing applications.
-Terms like "app," "user journey," and "onboarding" exclude libraries,
-SDKs, platforms, CLI tools, hardware devices, and internal components.
-Users building these product types encounter questions that don't apply
-and miss questions that do.
-
-The discover command uses product-neutral language throughout. Specific
-changes:
-
-- **Early classifier.** Phase 1 opens with "What kind of thing is
-  this?" (application, library/SDK, platform/service, CLI tool,
-  hardware device, other). The answer gates which subsequent prompts
-  are relevant — a library doesn't need onboarding-discovery
-  questions; hardware doesn't need integrations the same way.
-- **Terminology.** "App" becomes "product" or is dropped where the
-  sentence works without a noun. "User journey" becomes "workflow"
-  or "usage scenario." "Abandon your app" becomes "stop using this
-  or switch to an alternative." "Discovering and onboarding" becomes
-  "first encounter this, and what does getting started look like."
-- **Deep Dive table.** "User Experience" becomes "Usage & Workflow"
-  (covers CLI ergonomics, API surface, operator runbooks, physical
-  interaction). "Core Features" becomes "Capabilities." "Data &
-  Content" broadens to include state and signals for
-  hardware/embedded contexts.
-- **Argument hint.** `[app idea or problem area]` becomes
-  `[product idea or problem area]`.
+The discover command uses product-neutral language throughout. Phase 1
+opens with a product-type classifier (application, library/SDK,
+platform/service, CLI tool, hardware device, other) that gates which
+subsequent prompts are relevant.
 
 **Why:** symphonize targets any software product, not just consumer
 apps. Narrow language biases the interview toward GUI applications

--- a/commands/discover.md
+++ b/commands/discover.md
@@ -1,5 +1,5 @@
 ---
-argument-hint: [app idea or problem area]
+argument-hint: [product idea or problem area]
 description: Interview the user to produce or update REQUIREMENTS.md
 ---
 Read CONVENTIONS.md for governance file formats (§ Cross-document traceability).
@@ -24,10 +24,16 @@ applied at the requirements level.
 
 Open with these questions (adapt based on responses):
 
-- What problem does your app solve?
-- Who is your target user and what's their current workflow?
-- What's your vision for the final product?
-- What similar apps inspire you or compete with your idea?
+- What kind of thing is this? (application, library/SDK, platform/service,
+  CLI tool, hardware device, other)
+- What problem does it solve?
+- Who uses it and what's their current workflow?
+- What's your vision for the finished product?
+- What similar products inspire you or compete with your idea?
+
+The product-type answer gates subsequent prompts. A library doesn't need
+onboarding-discovery questions; hardware doesn't need integrations the
+same way. Adapt the interview accordingly.
 
 **Goal:** Establish clear understanding of the problem space and user needs
 before defining success.
@@ -53,9 +59,9 @@ prose. Skip prompts that don't apply; linger on those that spark insight.
 
 Define what success looks like *before* exploring features:
 
-- How would you measure success for this app?
-- What would make a user abandon your app?
-- How do you envision users discovering and onboarding?
+- How would you measure success for this product?
+- What would make someone stop using this or switch to an alternative?
+- How do people first encounter this, and what does getting started look like?
 - What must be true for this to be worth building?
 
 **Goal:** Establish observable, measurable acceptance conditions that
@@ -82,12 +88,12 @@ from Phase 2:
 
 | Area | Key Questions |
 |------|---------------|
-| **User Experience** | Walk through a typical user journey step-by-step |
-| **Core Features** | What are must-have vs. nice-to-have features? |
-| **Data & Content** | What information does the app store, display, or process? |
-| **Integrations** | External services or APIs needed? |
-| **Technical Constraints** | Platform preferences, performance requirements? |
-| **Business Logic** | Rules governing app behavior in different scenarios? |
+| **Usage & Workflow** | Walk through a typical usage scenario step-by-step |
+| **Capabilities** | What are must-have vs. nice-to-have capabilities? |
+| **Data, Content & State** | What information does the product store, display, process, or signal? |
+| **Integrations** | External services, APIs, or systems needed? |
+| **Technical Constraints** | Platform, environment, or performance requirements? |
+| **Business Logic** | Rules governing behavior in different scenarios? |
 
 **Pacing:** Ask 2-3 questions at a time. Don't overwhelm non-technical users.
 


### PR DESCRIPTION
## Summary

- Replace app-centric terminology in `commands/discover.md` with product-neutral language (application, library/SDK, platform/service, CLI tool, hardware device)
- Add early product-type classifier question in Phase 1 that gates subsequent prompts
- Generalize Deep Dive table: "User Experience" → "Usage & Workflow", "Core Features" → "Capabilities", "Data & Content" → "Data, Content & State"
- Reframe onboarding/abandonment questions to cover all product types
- Update SPEC.md §spec:product-type-agnostic-discovery to complete, compress section
- Remove completed §road:product-neutral-discover from ROADMAP.md

Workstream: §road:product-neutral-discover

## Test plan

- [ ] Verify `commands/discover.md` contains no remaining "app" references
- [ ] Verify Phase 1 opens with product-type classifier question
- [ ] Verify Deep Dive table uses new headings
- [ ] Verify CI passes (markdownlint, status lines, slugs, cross-references)