### PR TITLE
feat: batch — init scaffolds Vale prose-linting config

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,2 @@
 # symphonize — Roadmap
 
-## Prose linting
-
-Add Vale-based prose quality checks to the governance-lint
-workflow.
-
-### §road:init-scaffolds-vale
-Update init.md to scaffold `.vale.ini` and
-`styles/Requirements/` with the modal verb rules. Projects opt
-in to prose linting by having these files.

--- a/SPEC.md
+++ b/SPEC.md
@@ -147,7 +147,7 @@ translation from requirements to spec is where design decisions
 happen — that boundary should be explicit.
 
 ## Prose linting §spec:prose-linting
-*Status: in progress*
+*Status: complete*
 
 The governance-lint workflow validates structure (markdownlint) and
 cross-references (slug resolution), but not prose quality. SPEC.md

--- a/commands/init.md
+++ b/commands/init.md
@@ -54,6 +54,55 @@ Create at the repo root:
   {"MD013": false, "MD024": false, "MD036": false}
   ```
 
+### Prose linting (Vale)
+
+- **.vale.ini** — Vale config:
+  ```ini
+  StylesPath = styles
+  MinAlertLevel = warning
+
+  [SPEC.md]
+  BasedOnStyles = Requirements
+
+  [REQUIREMENTS.md]
+  BasedOnStyles = Requirements
+  ```
+- **styles/Requirements/MustDeprecated.yml** — flags deprecated `must`:
+  ```yaml
+  extends: existence
+  message: "'%s' is deprecated by IEEE. Use 'shall' for mandatory requirements."
+  ignorecase: true
+  level: error
+  scope: sentence
+  tokens:
+    - '\bmust\b'
+  ```
+- **styles/Requirements/WillDeprecated.yml** — flags deprecated `will`:
+  ```yaml
+  extends: existence
+  message: "'%s' is deprecated by IEEE for requirements. Use 'shall' for mandatory, 'should' for recommended."
+  ignorecase: true
+  level: warning
+  scope: sentence
+  tokens:
+    - '\bwill\b'
+  ```
+- **styles/Requirements/FillerPhrases.yml** — catches filler:
+  ```yaml
+  extends: existence
+  message: "Filler phrase '%s' — cut it."
+  ignorecase: true
+  level: warning
+  scope: sentence
+  tokens:
+    - 'it should be noted that'
+    - 'in order to'
+    - 'due to the fact that'
+    - 'it is important to note'
+    - 'at this point in time'
+    - 'for the purpose of'
+  ```
+
 ### CI workflows
 
 Create under `.github/workflows/`:


### PR DESCRIPTION
## Summary

- Add `.vale.ini` and `styles/Requirements/` (MustDeprecated, WillDeprecated, FillerPhrases) to the `/symphonize:init` scaffolding list in `commands/init.md`
- Mark §spec:prose-linting as complete and remove the completed workstream from ROADMAP.md
- Projects opt in to prose linting by running `/symphonize:init`, which now creates the Vale config alongside the existing markdownlint config

## Test plan

- [ ] Run `/symphonize:init` in a fresh project and verify `.vale.ini` and `styles/Requirements/*.yml` are created
- [ ] Confirm idempotent behavior: re-running init skips existing Vale files
- [ ] Verify governance-lint CI passes on this PR