### PR TITLE
feat: batch — init scaffolds Vale prose linting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,12 +11,3 @@ terms, add early product-type classifier question in Phase 1,
 generalize Deep Dive table headings (Usage & Workflow, Capabilities,
 broaden Data & Content), and reframe onboarding/abandonment
 questions to cover libraries, platforms, CLI tools, and hardware.
-## Prose linting
-
-Add Vale-based prose quality checks to the governance-lint
-workflow.
-
-### §road:init-scaffolds-vale
-Update init.md to scaffold `.vale.ini` and
-`styles/Requirements/` with the modal verb rules. Projects opt
-in to prose linting by having these files.

--- a/SPEC.md
+++ b/SPEC.md
@@ -147,7 +147,7 @@ translation from requirements to spec is where design decisions
 happen — that boundary should be explicit.
 
 ## Prose linting §spec:prose-linting
-*Status: in progress*
+*Status: complete*
 
 The governance-lint workflow validates structure (markdownlint) and
 cross-references (slug resolution), but not prose quality. SPEC.md

--- a/commands/init.md
+++ b/commands/init.md
@@ -54,6 +54,58 @@ Create at the repo root:
   {"MD013": false, "MD024": false, "MD036": false}
   ```
 
+### Prose linting (Vale)
+
+- **.vale.ini** — Vale config targeting governance files:
+  ```ini
+  StylesPath = styles
+  MinAlertLevel = warning
+
+  [SPEC.md]
+  BasedOnStyles = Requirements
+
+  [REQUIREMENTS.md]
+  BasedOnStyles = Requirements
+  ```
+
+- **styles/Requirements/MustDeprecated.yml** — flags `must` (deprecated by IEEE):
+  ```yaml
+  extends: existence
+  message: "'%s' is deprecated by IEEE. Use 'shall' for mandatory requirements."
+  ignorecase: true
+  level: error
+  scope: sentence
+  tokens:
+    - '\bmust\b'
+  ```
+
+- **styles/Requirements/WillDeprecated.yml** — flags `will` (deprecated by IEEE):
+  ```yaml
+  extends: existence
+  message: "'%s' is deprecated by IEEE for requirements. Use 'shall' for mandatory, 'should' for recommended."
+  ignorecase: true
+  level: warning
+  scope: sentence
+  tokens:
+    - '\bwill\b'
+  ```
+
+- **styles/Requirements/FillerPhrases.yml** — flags filler phrases:
+  ```yaml
+  extends: existence
+  message: "Filler phrase '%s' — cut it."
+  ignorecase: true
+  level: warning
+  scope: sentence
+  tokens:
+    - 'it should be noted that'
+    - 'in order to'
+    - 'due to the fact that'
+    - 'it is important to note'
+    - 'at this point in time'
+    - 'for the purpose of'
+  ```
+
 ### CI workflows
 
 Create under `.github/workflows/`:


### PR DESCRIPTION
## Summary

- **init-scaffolds-vale**: `commands/init.md` now scaffolds `.vale.ini` and `styles/Requirements/` (MustDeprecated, WillDeprecated, FillerPhrases) so target projects opt in to Vale prose linting by running `/symphonize:init`
- SPEC.md §spec:prose-linting status updated to `complete`
- Completed prose linting section removed from ROADMAP.md

## Test plan

- [ ] Run `/symphonize:init` in a fresh project and verify `.vale.ini` and `styles/Requirements/*.yml` are created
- [ ] Run `vale SPEC.md` in the scaffolded project to confirm rules activate
- [ ] Verify idempotent behavior: run `/symphonize:init` again, confirm Vale files are skipped