### PR TITLE
fix(next): correct shell injection syntax in next command

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,9 @@ README lags behind the codebase in several areas:
   commands — Usage as a numbered narrative, API as a table. Merge
   into one section. A table with brief descriptions is sufficient;
   the narrative framing ("you define, agents implement, you review")
-  belongs in the intro, not repeated per-command.
+  belongs in the intro, not repeated per-command. Lead with
+  `/symphonize:init` (one-time project setup), then the recurring
+  loop commands in pipeline order.
 - **Discovery is optional but recommended:** technical users can
   skip `/symphonize:discover` and jump straight to `/symphonize:plan`
   with a hand-written SPEC.md. Note this path exists but frame


### PR DESCRIPTION
## Summary

- `/symphonize:next` line 68 uses `!`cat ${CLAUDE_SKILL_DIR}/../BATCH_AGENT.md`` (bang outside backticks), which Claude Code doesn't recognize as a shell injection
- Claude Code skill files require `` `!command` `` (bang inside backticks) for dynamic content injection
- This causes every `/symphonize:next` invocation to fail when trying to read BATCH_AGENT.md

## Plan

The roadmap adds a single workstream `§road:fix-next-shell-expansion` for the one-line fix. Implementation is trivial — swap the `!` and opening backtick on line 68 of `commands/next.md`.

## Test plan

- [ ] Run `/symphonize:next` after the fix and verify BATCH_AGENT.md contents are injected into the agent prompt