### PR TITLE
feat(spec): plan unattended flag passthrough through agent hierarchy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,2 +1,12 @@
 # symphonize — Roadmap
 
+## Unattended flag passthrough
+
+- **unattended-flag-passthrough**: Pass `--unattended` explicitly
+  through the full agent hierarchy instead of relying on
+  `.claude/ralph-loop.local.md` file detection. Changes:
+  `orchestrate.md` (add `--unattended` to ralph-loop prompt),
+  `next.md` (read flag from args, remove file check, pass to
+  batch agent), `BATCH_AGENT.md` (pass `--unattended` to
+  sub-agents in Phase 3, add sub-agent non-interactive behavior
+  rule). Implements §spec:unattended-flag-passthrough.

--- a/SPEC.md
+++ b/SPEC.md
@@ -231,6 +231,51 @@ directives. Workaround: `/clear` and manually remove the flag
 file before planning. A proper fix requires the stop hook (in
 ralph-loop, not symphonize) to check active skill context.
 
+## Unattended flag passthrough §spec:unattended-flag-passthrough
+*Status: not started*
+
+When `/symphonize:orchestrate` starts a ralph-loop, every agent in
+the execution hierarchy runs unattended. The `--unattended` flag
+propagates explicitly through each layer — no agent infers
+unattended mode from file existence or ambient state.
+
+### Propagation chain
+
+1. `/symphonize:orchestrate` passes `--unattended` in the
+   ralph-loop prompt that invokes `/symphonize:next`.
+2. `/symphonize:next` reads `--unattended` from its arguments
+   (not from `.claude/ralph-loop.local.md`). Passes
+   `--unattended` to the batch agent it spawns.
+3. The batch agent (BATCH_AGENT.md) passes `--unattended` to
+   every sub-agent it spawns in Phase 3.
+4. Sub-agents operating in `--unattended` mode shall not surface
+   interactive prompts, approval gates, or questions to the user.
+   When a sub-agent encounters ambiguity it would normally ask
+   about, it makes a conservative choice and documents the
+   decision in its commit message.
+
+### Detection in `/next`
+
+When `--unattended` is present in `/next`'s arguments, the command
+sets `unattended = true`. When absent, `unattended = false`. The
+`.claude/ralph-loop.local.md` file check is removed from `/next`.
+
+### `/clean` unchanged
+
+`/symphonize:clean` checks `.claude/ralph-loop.local.md` to
+auto-detect cleanup mode. That check remains — `clean` runs in the
+main working tree where the file is visible, and mode auto-detect
+is a convenience, not a correctness concern.
+
+**Why:** the file-based detection couples symphonize to
+ralph-loop's internal file layout. The file is not git-tracked, so
+agents in worktrees cannot see it. More critically, even when the
+batch agent correctly receives `--unattended`, it does not
+propagate the flag to sub-agent workers. Those workers can surface
+interactive prompts that block the orchestration loop indefinitely
+with no user present. Explicit passthrough at every layer ensures
+the entire tree runs non-interactively.
+
 ## Governance consistency §spec:governance-consistency
 *Status: in progress*
 


### PR DESCRIPTION
## Summary

- Adds `§spec:unattended-flag-passthrough` requiring `--unattended` to propagate explicitly through the full agent hierarchy: `orchestrate` → `next` → batch agent → sub-agent workers
- Removes the fragile `.claude/ralph-loop.local.md` file check from `/next` detection — replaced by explicit argument passing
- Adds roadmap workstream `unattended-flag-passthrough` targeting four files: `orchestrate.md`, `next.md`, `BATCH_AGENT.md`, and sub-agent dispatch

## Problem

The orchestration loop hangs when sub-agent workers surface interactive prompts. The root cause is two-fold: `/next` detects unattended mode via a file that's invisible from worktrees, and even when the batch agent correctly runs unattended, it doesn't pass the flag to its workers.

## Test plan

- [ ] Review spec section for completeness — does the propagation chain cover all layers?
- [ ] Review roadmap workstream sizing — single workstream touching 4 small files
- [ ] Merge, then execute via `/symphonize:next unattended-flag-passthrough`