### PR TITLE
feat(commands): add /feedback for structured issue submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ jobs:
 | `/symphonize:review [PR]` | Review a PR — resolve conflicts, check out locally, guide integration testing |
 | `/symphonize:clean [--lite\|--full]` | Clean up after batch execution |
 | `/symphonize:lint [type]` | Validate governance files (markdownlint) |
+| `/symphonize:feedback` | Submit feedback or report a bug to the symphonize project |
 
 The batch agent protocol (`protocols/batch-agent.md`) manages
 sub-agent dispatch, merge conflict resolution, and CI verification.

--- a/SPEC.md
+++ b/SPEC.md
@@ -21,6 +21,7 @@ The command pipeline:
 7. `/symphonize:clean` — post-merge cleanup
 8. `/symphonize:lint` — governance file validation
 9. `/symphonize:init` — project scaffolding
+10. `/symphonize:feedback` — submit feedback to symphonize
 
 ## Governance lint command §spec:governance-lint
 *Status: complete*

--- a/commands/feedback.md
+++ b/commands/feedback.md
@@ -1,0 +1,115 @@
+---
+argument-hint: [bug, feature, or general feedback]
+description: Submit feedback or report a bug to the symphonize project
+---
+
+## Responsibility
+
+`/feedback` helps the user submit structured feedback to the
+symphonize project. It interviews the user briefly, drafts a
+GitHub issue, and opens it in the browser for review before
+submission.
+
+The issue targets `repentsinner/symphonize`, not the user's
+project repo.
+
+## Steps
+
+1. **Classify.** Ask the user what kind of feedback:
+   - **Bug** — something broken or unexpected
+   - **Feature request** — something missing or desired
+   - **General feedback** — workflow friction, documentation gaps,
+     suggestions
+
+2. **Gather context.** Based on the type:
+
+   **Bug:**
+   - What happened?
+   - What did you expect to happen?
+   - What command were you running? (`/discover`, `/plan`,
+     `/decompose`, `/next`, `/orchestrate`, `/review`)
+   - Can you reproduce it?
+   - What project type? (application, library, CLI, etc.)
+
+   **Feature request:**
+   - What problem would this solve?
+   - What does your current workaround look like?
+   - Which part of the pipeline does this affect?
+
+   **General feedback:**
+   - What's working well?
+   - What's not working well?
+   - What surprised you?
+
+3. **Draft the issue.** Write a title and body using the
+   appropriate template:
+
+   **Bug:**
+   ```markdown
+   ## What happened
+   <description>
+
+   ## Expected behavior
+   <description>
+
+   ## Steps to reproduce
+   1. Run `/symphonize:<command>`
+   2. ...
+
+   ## Context
+   - Project type: <type>
+   - Pipeline stage: <command>
+   ```
+
+   **Feature request:**
+   ```markdown
+   ## Problem
+   <what's missing or painful>
+
+   ## Proposed solution
+   <what the user wants>
+
+   ## Current workaround
+   <how they cope today>
+
+   ## Pipeline stage
+   <which command(s) this affects>
+   ```
+
+   **General feedback:**
+   ```markdown
+   ## Feedback
+   <description>
+
+   ## Pipeline stage
+   <which command(s) this relates to>
+   ```
+
+4. **Show the draft to the user.** Let them review and edit
+   before submission.
+
+5. **Open in browser.** Use `gh issue create --web` to open the
+   issue form pre-filled in the user's browser:
+
+   ```bash
+   gh issue create \
+     --repo repentsinner/symphonize \
+     --title "<title>" \
+     --body "<body>" \
+     --label "<bug|enhancement|feedback>" \
+     --web
+   ```
+
+   The `--web` flag opens the browser with the form pre-filled.
+   The user reviews, edits if needed, and submits. No issue is
+   created without the user clicking "Submit."
+
+## What /feedback does NOT do
+
+- Does not create issues without user review — `--web` always
+  opens the browser first
+- Does not include sensitive project details unless the user
+  explicitly provides them
+- Does not attach code, logs, or file contents automatically
+
+The user's input is: $1


### PR DESCRIPTION
## Summary

- New `/symphonize:feedback` command that interviews the user (bug/feature/general), drafts a structured GitHub issue, and opens it in the browser via `gh issue create --web` targeting `repentsinner/symphonize`
- The `--web` flag opens the browser with the form pre-filled — no issue is created without the user clicking Submit
- Keeps sensitive project details out unless the user explicitly includes them
- Updated README.md and SPEC.md command pipeline references

## Test plan

- [ ] Run `/symphonize:feedback` — confirm it asks for feedback type, gathers context, and opens the browser with a pre-filled issue form
- [ ] Verify `gh issue create --repo repentsinner/symphonize --web` opens correctly with title, body, and label