### PR TITLE
docs: post-merge cleanup — complete clean hygiene, empty roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,1 @@
 # symphonize — Roadmap
-
-## Clean working tree hygiene
-
-### §road:clean-phase-reorder
-
-Rewrite `commands/clean.md` full-mode phases: dirty-state check
-at entry (warn and abort if dirty, restore lock files), checkout
-main and fast-forward before governance doc updates, verify after
-commit. Ban `git stash`. §spec:clean-working-tree-hygiene
-
-**Verify:** Run `/symphonize:clean --full` with a dirty
-pubspec.lock. Confirm lock file is restored and clean proceeds.
-Run with a dirty source file. Confirm clean warns and aborts.
-Confirm verification runs on main, not a branch.

--- a/SPEC.md
+++ b/SPEC.md
@@ -395,50 +395,21 @@ Wake, "INVEST in Good Stories" (2003); Cockburn, "Elephant
 Carpaccio" exercise.
 
 ## Clean working tree hygiene §spec:clean-working-tree-hygiene
-*Status: in progress*
+*Status: complete*
 
-The `/symphonize:clean` full-mode command shall not stash, force-
-checkout, or silently discard uncommitted changes. When the working
-tree is dirty at the start of full-mode clean, the command warns
-with `git status` output and aborts. The user resolves dirty state
-before re-running.
+The `/symphonize:clean` full-mode command checks for dirty state
+at entry, checks out main before verification, and never stashes.
 
-### Phase ordering
+**Why no stashing:** stashes from branch-switching accumulate
+silently — the pop never happens. Lock file drift (the usual
+cause) is handled by restoring generated files; real dirty state
+aborts with a warning. A stash is a deferred decision disguised
+as cleanup.
 
-Full-mode clean checks out `main` and fast-forwards (`git pull
---ff-only`) before running verification (analyze, test). The
-current command runs verification after governance doc updates but
-before switching to main — verifying from a branch, not from the
-state that ships. Correct order:
-
-1. Git housekeeping (fetch, prune, branch/worktree cleanup, PR
-   supersession)
-2. Checkout main, fast-forward to `origin/main`
-3. Governance doc updates (roadmap, spec, changelog)
-4. Commit governance changes, push
-5. Verify (analyze, test) — now running against main
-
-### No implicit stashing
-
-The clean command shall not run `git stash` under any circumstance.
-Stashes created by branch-switching during cleanup accumulate
-silently — the pop or drop never happens, and `git stash list`
-grows without bound. The root cause is usually lock file drift
-(pubspec.lock, package-lock.json) from dependency resolution on
-different branches.
-
-If the working tree is dirty when clean needs to switch branches:
-
-- If the only dirty files are generated lock files, restore them
-  (`git restore <file>`) and proceed.
-- If other files are dirty, warn and abort. Uncommitted work is
-  the user's responsibility.
-
-**Why warn-and-abort, not stash:** a stash is a deferred decision
-disguised as cleanup. `/clean` runs at session boundaries where
-the user is present and can make the decision immediately. Silent
-stashing defers it indefinitely — the stash is forgotten, and the
-next `/clean` run creates another one.
+**Why verify from main:** the previous phase ordering ran
+verification from a branch, not from the state that ships.
+Checking out main and fast-forwarding before governance doc
+updates ensures tests run against the shipped state.
 
 ## Pre-PR review gates §spec:pre-pr-review-gates
 *Status: complete*


### PR DESCRIPTION
## Summary

- Remove `§road:clean-phase-reorder` from ROADMAP.md — shipped in #99 but batch agent forgot to clean up
- Update §spec:clean-working-tree-hygiene status to `complete`, compress section (retain rationale, remove implementation detail now in clean.md)
- Delete `.symphonize-progress.local.md` — loop complete
- ROADMAP.md is now empty (all workstreams from this session shipped)

## Test plan

- [ ] markdownlint passes on SPEC.md, ROADMAP.md, README.md
- [ ] Vale passes on SPEC.md, REQUIREMENTS.md
- [ ] SPEC.md status lines match reality