### PR TITLE
feat(roadmap): simplify gate workstream

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,1 +1,22 @@
 # symphonize — Roadmap
+
+## Simplify gate in batch-agent protocol
+
+### §road:batch-agent-simplify-phase
+
+Add Phase 5a (simplify gate) to `protocols/batch-agent.md` between
+Phase 5 (Verify) and Phase 5b (`/security-review`), implementing
+single invocation, doc-only skip detection, fix review, and CI
+re-run per §spec:simplify-gate.
+
+**Verify:** Read `protocols/batch-agent.md` at the PR branch. Confirm
+Phase 5a sits between Phase 5 and Phase 5b with these elements: (1)
+skip-condition check via `git diff --name-only` against merge base,
+excluding non-source files; (2) single `/simplify` invocation, not a
+loop; (3) batch-agent review of applied fixes with revert-on-conflict
+instruction; (4) mandatory CI re-run after fixes settle; (5)
+explicit handoff to Phase 5b. Cross-reference §spec:simplify-gate
+and confirm every design decision in the spec (mandatory, single
+invocation, skip condition, ordering, fix review) is represented in
+the protocol text. Run `/symphonize:lint` and confirm no
+markdownlint errors.


### PR DESCRIPTION
## Summary

Adds the first roadmap section for §spec:simplify-gate (merged in #106): a single workstream `§road:batch-agent-simplify-phase` that updates `protocols/batch-agent.md` to introduce Phase 5a between Verify and /security-review.

Single workstream because the spec section affects one file with a focused change. The verify block enumerates the five design elements the protocol text must cover — skip-condition check, single invocation, fix review, CI re-run, Phase 5b handoff — giving the implementation agent explicit acceptance criteria.

## Test plan

- [x] `markdownlint-cli2 ROADMAP.md` — passes
- [ ] Reviewer confirms the workstream traces cleanly to §spec:simplify-gate
- [ ] Reviewer confirms the Verify block covers every decision in the spec section
- [ ] After merge, `/symphonize:next` selects `§road:batch-agent-simplify-phase` and produces a PR editing `protocols/batch-agent.md`