### PR TITLE
feat(roadmap): orchestration loop /goal migration workstream

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,1 +1,25 @@
 # symphonize — Roadmap
+
+## Orchestration loop via /goal
+
+### §road:migrate-orchestrate-to-goal
+
+Replace `/ralph-loop:ralph-loop` with `/goal` in
+`commands/orchestrate.md`, and retire residual ralph-loop coupling
+in `commands/clean.md` (flag-file mode auto-detect),
+`protocols/batch-agent.md`, `README.md`,
+`§spec:unattended-flag-passthrough`, and the known-issue note in
+`§spec:progress-file-location`. §spec:orchestration-loop
+
+**Verify:** From a project with a populated ROADMAP section, run
+`/symphonize:orchestrate`. Confirm: (1) it first invokes
+`/symphonize:clean --lite`; (2) it sets an active `/goal`, visible
+via `/goal` with no arguments, whose condition targets section
+completion; (3) `/symphonize:next --unattended` runs and produces
+at least one PR; (4) the goal clears automatically once the
+section reports all unblocked workstreams attempted. In a second
+session in the same project, run `/symphonize:plan` and confirm
+no stop-hook directives fire from ralph-loop. Finally,
+`grep -r 'ralph' commands/ protocols/ README.md SPEC.md` shall
+return no matches in active code paths (CHANGELOG.md may retain
+historical references).


### PR DESCRIPTION
## Summary

- Adds `## Orchestration loop via /goal` section to ROADMAP.md with
  a single workstream `§road:migrate-orchestrate-to-goal`.
- Traces to `§spec:orchestration-loop` (merged in #116).

## Workstream scope

Single workstream because the migration is cohesive: rewriting
`commands/orchestrate.md` is the surface change, with mechanical
cleanup of ralph-loop references across `commands/clean.md`,
`protocols/batch-agent.md`, `README.md`, and two existing SPEC.md
sections that document ralph-loop-specific mechanics
(`§spec:unattended-flag-passthrough`, `§spec:progress-file-location`).
Fits one batch.

## Verify block

End-to-end exercise of `/symphonize:orchestrate` plus a regression
check that `/symphonize:plan` no longer sees ralph-loop stop-hook
directives in a project with no active loop.

## Out of scope

- The user-local `.claude/settings.local.json` permission entry for
  ralph-loop is gitignored — not part of the workstream. Users can
  drop it manually after the migration lands.
- CHANGELOG.md historical references stay.

## Test plan

- [ ] Review workstream sentence — is the affected-file list complete?
- [ ] Review Verify block — concrete enough for batch agent / reviewer?
- [ ] `/symphonize:lint` passes (verified locally: 0 errors)