### PR TITLE
docs: record conventions-kernel extraction across governance docs

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -146,3 +146,29 @@ not an active requirement.
 - Batch triage for processing multiple issues in one session
 - Stale issue bot for auto-closing unresponsive `needs-info` issues
 - Pipeline auto-chaining with human review gates between stages
+
+## Modular adoption §req:modular-adoption
+
+Symphonize bundles three separable capabilities in one plugin: curating
+governance intent (`/discover`, `/plan`, `/roadmap`), dispatching
+execution (`/next`, `/orchestrate`, `/review`, `/clean`), and the
+conventions contract beneath both — the governance file formats, the
+`§`-slug traceability grammar, the scaffolder that installs them, and the
+CI workflow that enforces them.
+
+Adopters need these separately:
+
+- A team may want the conventions and their linting without symphonize's
+  agent-swarm execution model, or the planning discipline without the
+  dispatch machinery. The monolith forces all-or-nothing adoption.
+- The conventions contract should serve as the one source of truth that
+  symphonize, future symphonize components, and external adopters all
+  consume. Holding it inside symphonize couples every adopter to
+  symphonize's release cadence and full opinion.
+- A contract and the linter that enforces it drift when they live apart.
+  The enforcement workflow once validated numbered sections while the
+  grammar had moved to slug-style headings, and nothing caught the
+  divergence. The contract and its enforcement should share one version.
+
+The conventions layer separates first, because every other component and
+every adopter depends on it.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,21 +17,24 @@ with `traceability`, `vale`, and `extended-globs` enabled; CI passes on
 this repo's governance files; symphonize no longer hosts its own
 `governance-lint.yml` as the source of truth.
 
-## Adopt the kernel's materialized conventions
+## Relocate CONVENTIONS.md content into commands
 
-Blocked — depends on the kernel publishing the canonical CONVENTIONS.md
-and `contracts-version` marker. Unblocked when §road:consume-kernel-lint
-lands, since the lint version anchors the contract version.
+Not blocked — symphonize-internal, can proceed before the kernel ships.
+Prepares `CONVENTIONS.md` for deletion (§road:remove-kernel-originals);
+the structural grammar needs no replacement file (the kernel's linter
+enforces it), so only the methodology and process content must move.
 
-### §road:adopt-kernel-conventions
+### §road:relocate-conventions-content
 
-Replace symphonize's canonical `CONVENTIONS.md` with a materialized copy
-from the kernel carrying a `contracts-version` marker matching the
-referenced kernel version. §spec:conventions-kernel
+Move `CONVENTIONS.md`'s authoring methodology inline into the curation
+commands and its process discipline into the dispatch commands and
+`protocols/batch-agent.md`, repointing each command that reads
+`CONVENTIONS.md`. §spec:conventions-kernel
 
-**Verify:** `CONVENTIONS.md` carries a `contracts-version` marker; the
-marker matches the kernel major referenced in `ci.yml`; governance-lint
-passes.
+**Verify:** `discover`/`plan`/`roadmap` carry their methodology inline;
+`next`/`orchestrate`/`clean` and `batch-agent.md` carry the process
+discipline; no command depends on a `CONVENTIONS.md` section slated for
+deletion; governance-lint passes.
 
 ## Adopt the kernel's scaffolder
 
@@ -51,16 +54,19 @@ references a coherent kernel.
 
 ## Remove symphonize's superseded kernel originals
 
-Blocked — depends on the three adoption workstreams above. Unblocked when
-consumption is verified end-to-end; removing originals first would orphan
-adopters.
+Blocked — depends on §road:consume-kernel-lint,
+§road:adopt-kernel-scaffolder, and §road:relocate-conventions-content.
+Unblocked when consumption is verified end-to-end and `CONVENTIONS.md`'s
+content has moved; removing originals first would orphan adopters or
+strand command references.
 
 ### §road:remove-kernel-originals
 
-Delete symphonize's embedded `governance-lint.yml`, its canonical
-`CONVENTIONS.md` ownership, and the duplicated `/init` scaffolding now
-served by the kernel. §spec:conventions-kernel
+Delete symphonize's embedded `governance-lint.yml`, its `CONVENTIONS.md`,
+and the duplicated `/init` scaffolding now served by the kernel.
+§spec:conventions-kernel
 
-**Verify:** no embedded `governance-lint.yml` remains; `CONVENTIONS.md`
-is materialized from the kernel, not canonical; `/symphonize:init`
-delegates; CI is green; `grep` finds no duplicated scaffolding templates.
+**Verify:** no embedded `governance-lint.yml` remains; `CONVENTIONS.md` is
+deleted with no replacement file; `/symphonize:init` delegates to the
+kernel scaffolder; CI is green via the kernel workflow; `grep` finds no
+command referencing the removed `CONVENTIONS.md`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,8 +3,8 @@
 ## Consume the kernel's enforcement workflow
 
 Blocked — depends on the kernel publishing the opt-in governance checks
-(`traceability`, `vale`, `extended-globs`) at a referenceable major tag.
-Unblocked when the kernel ships those inputs.
+(`traceability`, `vale`) at a referenceable major tag. Unblocked when the
+kernel ships those inputs.
 
 ### §road:consume-kernel-lint
 
@@ -13,9 +13,9 @@ with the governance checks enabled, retiring the embedded reusable
 workflow once CI is green. §spec:conventions-kernel
 
 **Verify:** `ci.yml` calls the kernel's `governance-lint.yml@<major>`
-with `traceability`, `vale`, and `extended-globs` enabled; CI passes on
-this repo's governance files; symphonize no longer hosts its own
-`governance-lint.yml` as the source of truth.
+with `traceability` and `vale` enabled; CI passes on this repo's
+governance files; symphonize no longer hosts its own `governance-lint.yml`
+as the source of truth.
 
 ## Relocate CONVENTIONS.md content into commands
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,26 +1,25 @@
 # symphonize — Roadmap
 
-## Consume the kernel's enforcement workflow
+## Consume the schema's enforcement workflow
 
-Blocked — depends on the kernel publishing the full-schema
-`governance-lint.yml` at a referenceable major tag. Unblocked when the
-kernel ships it.
+Blocked — depends on the schema's `governance-lint.yml` reaching a
+referenceable major tag. Unblocked when it ships.
 
-### §road:consume-kernel-lint
+### §road:consume-schema-lint
 
-Point `.github/workflows/ci.yml` at the kernel's `governance-lint.yml`,
+Point `.github/workflows/ci.yml` at the schema's `governance-lint.yml`,
 retiring the embedded reusable workflow once CI is green.
-§spec:conventions-kernel
+§spec:governance-schema
 
-**Verify:** `ci.yml` calls the kernel's `governance-lint.yml@<major>`; CI
+**Verify:** `ci.yml` calls the schema's `governance-lint.yml@<major>`; CI
 passes on this repo's governance files; symphonize no longer hosts its own
 `governance-lint.yml` as the source of truth.
 
 ## Relocate CONVENTIONS.md content into commands
 
-Not blocked — symphonize-internal, can proceed before the kernel ships.
-Prepares `CONVENTIONS.md` for deletion (§road:remove-kernel-originals);
-the structural grammar needs no replacement file (the kernel's linter
+Not blocked — symphonize-internal, can proceed before the schema ships.
+Prepares `CONVENTIONS.md` for deletion (§road:remove-schema-originals);
+the structural grammar needs no replacement file (the schema's linter
 enforces it), so only the methodology and process content must move.
 
 ### §road:relocate-conventions-content
@@ -28,44 +27,44 @@ enforces it), so only the methodology and process content must move.
 Move `CONVENTIONS.md`'s authoring methodology inline into the curation
 commands and its process discipline into the dispatch commands and
 `protocols/batch-agent.md`, repointing each command that reads
-`CONVENTIONS.md`. §spec:conventions-kernel
+`CONVENTIONS.md`. §spec:governance-schema
 
 **Verify:** `discover`/`plan`/`roadmap` carry their methodology inline;
 `next`/`orchestrate`/`clean` and `batch-agent.md` carry the process
 discipline; no command depends on a `CONVENTIONS.md` section slated for
 deletion; governance-lint passes.
 
-## Adopt the kernel's scaffolder
+## Adopt the schema's scaffolder
 
-Blocked — depends on the kernel publishing the scaffolder plugin.
-Unblocked when the kernel's scaffolder is installable as a plugin.
+Blocked — depends on the schema's scaffolder being installable as a
+plugin. Unblocked when it ships.
 
-### §road:adopt-kernel-scaffolder
+### §road:adopt-schema-scaffolder
 
-Make `/symphonize:init` defer to the kernel's scaffolder and declare a
-plugin dependency on the kernel in symphonize's plugin manifest.
-§spec:conventions-kernel
+Make `/symphonize:init` defer to the schema's scaffolder and declare a
+plugin dependency on the schema in symphonize's plugin manifest.
+§spec:governance-schema
 
 **Verify:** symphonize's `.claude-plugin` manifest declares a dependency
-on the kernel plugin; `/symphonize:init` no longer carries its own
+on the schema's plugin; `/symphonize:init` no longer carries its own
 governance-file and CONVENTIONS scaffolding logic; a scaffolded test repo
-references a coherent kernel.
+references a coherent schema.
 
-## Remove symphonize's superseded kernel originals
+## Remove symphonize's superseded originals
 
-Blocked — depends on §road:consume-kernel-lint,
-§road:adopt-kernel-scaffolder, and §road:relocate-conventions-content.
+Blocked — depends on §road:consume-schema-lint,
+§road:adopt-schema-scaffolder, and §road:relocate-conventions-content.
 Unblocked when consumption is verified end-to-end and `CONVENTIONS.md`'s
 content has moved; removing originals first would orphan adopters or
 strand command references.
 
-### §road:remove-kernel-originals
+### §road:remove-schema-originals
 
 Delete symphonize's embedded `governance-lint.yml`, its `CONVENTIONS.md`,
-and the duplicated `/init` scaffolding now served by the kernel.
-§spec:conventions-kernel
+and the duplicated `/init` scaffolding now served by the schema.
+§spec:governance-schema
 
 **Verify:** no embedded `governance-lint.yml` remains; `CONVENTIONS.md` is
 deleted with no replacement file; `/symphonize:init` delegates to the
-kernel scaffolder; CI is green via the kernel workflow; `grep` finds no
-command referencing the removed `CONVENTIONS.md`.
+schema's scaffolder; CI is green via the schema's workflow; `grep` finds
+no command referencing the removed `CONVENTIONS.md`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,20 +2,19 @@
 
 ## Consume the kernel's enforcement workflow
 
-Blocked — depends on the kernel publishing the opt-in governance checks
-(`traceability`, `vale`) at a referenceable major tag. Unblocked when the
-kernel ships those inputs.
+Blocked — depends on the kernel publishing the full-schema
+`governance-lint.yml` at a referenceable major tag. Unblocked when the
+kernel ships it.
 
 ### §road:consume-kernel-lint
 
-Point `.github/workflows/ci.yml` at the kernel's `governance-lint.yml`
-with the governance checks enabled, retiring the embedded reusable
-workflow once CI is green. §spec:conventions-kernel
+Point `.github/workflows/ci.yml` at the kernel's `governance-lint.yml`,
+retiring the embedded reusable workflow once CI is green.
+§spec:conventions-kernel
 
-**Verify:** `ci.yml` calls the kernel's `governance-lint.yml@<major>`
-with `traceability` and `vale` enabled; CI passes on this repo's
-governance files; symphonize no longer hosts its own `governance-lint.yml`
-as the source of truth.
+**Verify:** `ci.yml` calls the kernel's `governance-lint.yml@<major>`; CI
+passes on this repo's governance files; symphonize no longer hosts its own
+`governance-lint.yml` as the source of truth.
 
 ## Relocate CONVENTIONS.md content into commands
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,1 +1,66 @@
 # symphonize — Roadmap
+
+## Consume the kernel's enforcement workflow
+
+Blocked — depends on the kernel publishing the opt-in governance checks
+(`traceability`, `vale`, `extended-globs`) at a referenceable major tag.
+Unblocked when the kernel ships those inputs.
+
+### §road:consume-kernel-lint
+
+Point `.github/workflows/ci.yml` at the kernel's `governance-lint.yml`
+with the governance checks enabled, retiring the embedded reusable
+workflow once CI is green. §spec:conventions-kernel
+
+**Verify:** `ci.yml` calls the kernel's `governance-lint.yml@<major>`
+with `traceability`, `vale`, and `extended-globs` enabled; CI passes on
+this repo's governance files; symphonize no longer hosts its own
+`governance-lint.yml` as the source of truth.
+
+## Adopt the kernel's materialized conventions
+
+Blocked — depends on the kernel publishing the canonical CONVENTIONS.md
+and `contracts-version` marker. Unblocked when §road:consume-kernel-lint
+lands, since the lint version anchors the contract version.
+
+### §road:adopt-kernel-conventions
+
+Replace symphonize's canonical `CONVENTIONS.md` with a materialized copy
+from the kernel carrying a `contracts-version` marker matching the
+referenced kernel version. §spec:conventions-kernel
+
+**Verify:** `CONVENTIONS.md` carries a `contracts-version` marker; the
+marker matches the kernel major referenced in `ci.yml`; governance-lint
+passes.
+
+## Adopt the kernel's scaffolder
+
+Blocked — depends on the kernel publishing the scaffolder plugin.
+Unblocked when the kernel's scaffolder is installable as a plugin.
+
+### §road:adopt-kernel-scaffolder
+
+Make `/symphonize:init` defer to the kernel's scaffolder and declare a
+plugin dependency on the kernel in symphonize's plugin manifest.
+§spec:conventions-kernel
+
+**Verify:** symphonize's `.claude-plugin` manifest declares a dependency
+on the kernel plugin; `/symphonize:init` no longer carries its own
+governance-file and CONVENTIONS scaffolding logic; a scaffolded test repo
+references a coherent kernel.
+
+## Remove symphonize's superseded kernel originals
+
+Blocked — depends on the three adoption workstreams above. Unblocked when
+consumption is verified end-to-end; removing originals first would orphan
+adopters.
+
+### §road:remove-kernel-originals
+
+Delete symphonize's embedded `governance-lint.yml`, its canonical
+`CONVENTIONS.md` ownership, and the duplicated `/init` scaffolding now
+served by the kernel. §spec:conventions-kernel
+
+**Verify:** no embedded `governance-lint.yml` remains; `CONVENTIONS.md`
+is materialized from the kernel, not canonical; `/symphonize:init`
+delegates; CI is green; `grep` finds no duplicated scaffolding templates.

--- a/SPEC.md
+++ b/SPEC.md
@@ -632,11 +632,13 @@ tree. Symphonize delegates to the linter's native scoping.
 *Status: not started*
 
 A dedicated kernel repository — currently `bug-free-happiness` — owns the
-conventions kernel: the governance contract (file formats, the
-`§req:`/`§spec:`/`§road:` slug grammar, the status-line format), the
-scaffolder that materializes it, and the reusable workflow that enforces
-it. Symphonize consumes that kernel as one governance-system adopter; it
-no longer owns the contract. §req:modular-adoption
+conventions kernel: the **structural** governance contract (file formats,
+the `§req:`/`§spec:`/`§road:` slug grammar, the status-line format, and
+cross-reference rules), the scaffolder that materializes it, and the
+reusable workflow that enforces it. Symphonize consumes that structural
+contract as one governance-system adopter. Symphonize keeps its authoring
+methodology and process discipline — these are symphonize's own opinion,
+not part of the shared kernel contract. §req:modular-adoption
 
 In the target state:
 
@@ -644,9 +646,13 @@ In the target state:
   governance checks (traceability, prose, extended globs) enabled,
   instead of shipping its own `governance-lint.yml`. This supersedes
   §spec:reusable-ci and §spec:dogfooding.
-- Symphonize's `CONVENTIONS.md` holds a materialized copy of the kernel's
-  canonical grammar and carries a `contracts-version` marker, instead of
-  serving as the canonical source. This supersedes
+- Symphonize's `CONVENTIONS.md` splits three ways. The structural grammar
+  becomes a materialized copy from the kernel carrying a
+  `contracts-version` marker. The authoring methodology (declarative spec
+  writing, vertical slicing, interview frameworks, compression) moves into
+  symphonize's curation commands. The process discipline (branching,
+  commit conventions, quality gate) moves into its dispatch commands. Only
+  the structural slice comes from the kernel. This supersedes
   §spec:self-contained-conventions.
 - `/symphonize:init` defers to the kernel's scaffolder, and symphonize
   declares a plugin dependency on the kernel. This supersedes the
@@ -672,7 +678,10 @@ kernel.
 
 **Direction:** the kernel extraction is the first step toward decomposing
 symphonize into independently-adoptable layers — a curation layer and a
-dispatch layer over the shared kernel. This section covers only the
+dispatch layer over the shared kernel. The three-way split of today's
+`CONVENTIONS.md` mirrors that layering: the structural slice anchors the
+kernel, the authoring methodology becomes curation's, and the process
+discipline becomes dispatch's. This section covers only the
 conventions-kernel boundary; the further splits await their own spec
 sections.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -627,3 +627,56 @@ means deleting them. No registry to maintain, no sync to drift.
 **Why no symphonize-specific lint inheritance:** markdownlint, Vale,
 and similar tools already resolve config by walking up the directory
 tree. Symphonize delegates to the linter's native scoping.
+
+## Conventions kernel extraction §spec:conventions-kernel
+*Status: not started*
+
+A dedicated kernel repository — currently `bug-free-happiness` — owns the
+conventions kernel: the governance contract (file formats, the
+`§req:`/`§spec:`/`§road:` slug grammar, the status-line format), the
+scaffolder that materializes it, and the reusable workflow that enforces
+it. Symphonize consumes that kernel as one governance-system adopter; it
+no longer owns the contract. §req:modular-adoption
+
+In the target state:
+
+- Symphonize's CI references the kernel's enforcement workflow with the
+  governance checks (traceability, prose, extended globs) enabled,
+  instead of shipping its own `governance-lint.yml`. This supersedes
+  §spec:reusable-ci and §spec:dogfooding.
+- Symphonize's `CONVENTIONS.md` holds a materialized copy of the kernel's
+  canonical grammar and carries a `contracts-version` marker, instead of
+  serving as the canonical source. This supersedes
+  §spec:self-contained-conventions.
+- `/symphonize:init` defers to the kernel's scaffolder, and symphonize
+  declares a plugin dependency on the kernel. This supersedes the
+  scaffolding ownership in §spec:project-scaffolding.
+
+The kernel repository's own SPEC.md specifies the kernel's design —
+single repo, three faces, and the version-coherence contract. Symphonize
+references that spec instead of restating it.
+
+**Why extract:** a linter is the executable form of the contract.
+Co-locating the contract and its enforcement in the kernel makes their
+coherence structural — one version moves both — and prevents the
+numbered-versus-slug drift that a split-repo arrangement already
+produced. Externalizing the contract lets adopters take the conventions
+without symphonize's execution model and gives every component one source
+of truth for valid governance. §req:modular-adoption
+
+**Why consume rather than own:** owning the contract made symphonize the
+de-facto kernel for every adopter, coupling them to its release cadence
+and full opinion. As a consumer, symphonize keeps its execution and
+curation opinions to itself while the shared contract lives in the
+kernel.
+
+**Direction:** the kernel extraction is the first step toward decomposing
+symphonize into independently-adoptable layers — a curation layer and a
+dispatch layer over the shared kernel. This section covers only the
+conventions-kernel boundary; the further splits await their own spec
+sections.
+
+**Tradeoff accepted:** a cross-repo dependency replaces an in-repo one.
+Symphonize's CI and scaffolding depend on a published kernel release. The
+`contracts-version` marker makes a kernel/consumer mismatch detectable
+rather than silent.

--- a/SPEC.md
+++ b/SPEC.md
@@ -645,9 +645,10 @@ not part of the shared kernel contract. §req:modular-adoption
 In the target state:
 
 - Symphonize's CI references the kernel's enforcement workflow with the
-  governance checks (traceability, prose, extended globs) enabled,
-  instead of shipping its own `governance-lint.yml`. This supersedes
-  §spec:reusable-ci and §spec:dogfooding.
+  governance checks (traceability and prose) enabled, instead of shipping
+  its own `governance-lint.yml`. CHANGELOG.md stays unenforced — it is
+  release-please's generated artifact. This supersedes §spec:reusable-ci
+  and §spec:dogfooding.
 - Symphonize's `CONVENTIONS.md` is deleted, not replaced. Its three kinds
   of content disperse: the structural grammar needs no per-repo file —
   the kernel's linter enforces it and the curate/dispatch commands are

--- a/SPEC.md
+++ b/SPEC.md
@@ -634,9 +634,11 @@ tree. Symphonize delegates to the linter's native scoping.
 A dedicated kernel repository — currently `bug-free-happiness` — owns the
 conventions kernel: the **structural** governance contract (file formats,
 the `§req:`/`§spec:`/`§road:` slug grammar, the status-line format, and
-cross-reference rules), the scaffolder that materializes it, and the
-reusable workflow that enforces it. Symphonize consumes that structural
-contract as one governance-system adopter. Symphonize keeps its authoring
+cross-reference rules), the scaffolder that wires a repo up to it, and the
+reusable workflow that enforces it. The contract ships no document to
+adopters — the linter is its executable form and the plugins are built
+against the grammar. Symphonize consumes that structural contract as one
+governance-system adopter. Symphonize keeps its authoring
 methodology and process discipline — these are symphonize's own opinion,
 not part of the shared kernel contract. §req:modular-adoption
 
@@ -646,17 +648,19 @@ In the target state:
   governance checks (traceability, prose, extended globs) enabled,
   instead of shipping its own `governance-lint.yml`. This supersedes
   §spec:reusable-ci and §spec:dogfooding.
-- Symphonize's `CONVENTIONS.md` splits three ways. The structural grammar
-  becomes a materialized copy from the kernel carrying a
-  `contracts-version` marker. The authoring methodology (declarative spec
-  writing, vertical slicing, interview frameworks, compression) moves into
-  symphonize's curation commands. The process discipline (branching,
-  commit conventions, quality gate) moves into its dispatch commands. Only
-  the structural slice comes from the kernel. This supersedes
-  §spec:self-contained-conventions.
+- Symphonize's `CONVENTIONS.md` is deleted, not replaced. Its three kinds
+  of content disperse: the structural grammar needs no per-repo file —
+  the kernel's linter enforces it and the curate/dispatch commands are
+  built against it; the authoring methodology (declarative spec writing,
+  vertical slicing, interview frameworks, compression) moves inline into
+  the curation commands; the process discipline (branching, commit
+  conventions, quality gate) moves into the dispatch commands and the
+  batch-agent protocol. This supersedes §spec:self-contained-conventions.
 - `/symphonize:init` defers to the kernel's scaffolder, and symphonize
-  declares a plugin dependency on the kernel. This supersedes the
-  scaffolding ownership in §spec:project-scaffolding.
+  declares a plugin dependency on the kernel — the dependency pin and the
+  CI workflow ref together establish which kernel version symphonize
+  targets. This supersedes the scaffolding ownership in
+  §spec:project-scaffolding.
 
 The kernel repository's own SPEC.md specifies the kernel's design —
 single repo, three faces, and the version-coherence contract. Symphonize
@@ -687,5 +691,6 @@ sections.
 
 **Tradeoff accepted:** a cross-repo dependency replaces an in-repo one.
 Symphonize's CI and scaffolding depend on a published kernel release. The
-`contracts-version` marker makes a kernel/consumer mismatch detectable
-rather than silent.
+pinned workflow ref and the plugin dependency range — both machine-checked
+— keep symphonize and the kernel on one version, with no bespoke marker to
+maintain.

--- a/SPEC.md
+++ b/SPEC.md
@@ -644,9 +644,9 @@ not part of the shared kernel contract. §req:modular-adoption
 
 In the target state:
 
-- Symphonize's CI references the kernel's enforcement workflow with the
-  governance checks (traceability and prose) enabled, instead of shipping
-  its own `governance-lint.yml`. CHANGELOG.md stays unenforced — it is
+- Symphonize's CI references the kernel's enforcement workflow instead of
+  shipping its own `governance-lint.yml`; the workflow runs the full
+  schema with no toggles to set. CHANGELOG.md stays unenforced — it is
   release-please's generated artifact. This supersedes §spec:reusable-ci
   and §spec:dogfooding.
 - Symphonize's `CONVENTIONS.md` is deleted, not replaced. Its three kinds

--- a/SPEC.md
+++ b/SPEC.md
@@ -628,70 +628,69 @@ means deleting them. No registry to maintain, no sync to drift.
 and similar tools already resolve config by walking up the directory
 tree. Symphonize delegates to the linter's native scoping.
 
-## Conventions kernel extraction §spec:conventions-kernel
+## Governance-schema extraction §spec:governance-schema
 *Status: not started*
 
-A dedicated kernel repository — currently `bug-free-happiness` — owns the
-conventions kernel: the **structural** governance contract (file formats,
-the `§req:`/`§spec:`/`§road:` slug grammar, the status-line format, and
-cross-reference rules), the scaffolder that wires a repo up to it, and the
-reusable workflow that enforces it. The contract ships no document to
-adopters — the linter is its executable form and the plugins are built
-against the grammar. Symphonize consumes that structural contract as one
-governance-system adopter. Symphonize keeps its authoring
-methodology and process discipline — these are symphonize's own opinion,
-not part of the shared kernel contract. §req:modular-adoption
+Symphonize's governance-schema — the structural definition of its
+governance documents (file formats, the `§req:`/`§spec:`/`§road:` slug
+grammar, the status-line format, cross-reference rules) plus the workflow
+that enforces it and the scaffolder that wires a repo up to it — lives in
+a dedicated repository (`bug-free-happiness`), not inside symphonize. The
+schema ships no document to adopters: the linter is its executable form,
+and symphonize's commands are built against the grammar. Symphonize
+consumes the schema; it keeps its authoring methodology and process
+discipline, which are symphonize's own opinion and not part of the shared
+schema. §req:modular-adoption
 
 In the target state:
 
-- Symphonize's CI references the kernel's enforcement workflow instead of
+- Symphonize's CI references the schema's enforcement workflow instead of
   shipping its own `governance-lint.yml`; the workflow runs the full
   schema with no toggles to set. CHANGELOG.md stays unenforced — it is
   release-please's generated artifact. This supersedes §spec:reusable-ci
   and §spec:dogfooding.
 - Symphonize's `CONVENTIONS.md` is deleted, not replaced. Its three kinds
   of content disperse: the structural grammar needs no per-repo file —
-  the kernel's linter enforces it and the curate/dispatch commands are
+  the schema's linter enforces it and the curate/dispatch commands are
   built against it; the authoring methodology (declarative spec writing,
   vertical slicing, interview frameworks, compression) moves inline into
   the curation commands; the process discipline (branching, commit
   conventions, quality gate) moves into the dispatch commands and the
   batch-agent protocol. This supersedes §spec:self-contained-conventions.
-- `/symphonize:init` defers to the kernel's scaffolder, and symphonize
-  declares a plugin dependency on the kernel — the dependency pin and the
-  CI workflow ref together establish which kernel version symphonize
+- `/symphonize:init` defers to the schema's scaffolder, and symphonize
+  declares a plugin dependency on the schema — the dependency pin and the
+  CI workflow ref together establish which schema version symphonize
   targets. This supersedes the scaffolding ownership in
   §spec:project-scaffolding.
 
-The kernel repository's own SPEC.md specifies the kernel's design —
-single repo, three faces, and the version-coherence contract. Symphonize
-references that spec instead of restating it.
+The schema repository's own SPEC.md specifies its design — single repo,
+three faces, and the version-coherence contract. Symphonize references
+that spec instead of restating it.
 
-**Why extract:** a linter is the executable form of the contract.
-Co-locating the contract and its enforcement in the kernel makes their
-coherence structural — one version moves both — and prevents the
-numbered-versus-slug drift that a split-repo arrangement already
-produced. Externalizing the contract lets adopters take the conventions
-without symphonize's execution model and gives every component one source
-of truth for valid governance. §req:modular-adoption
+**Why a separate schema:** a linter is the executable form of the schema,
+so co-locating the grammar and its enforcement on one version line keeps
+them from drifting — they did once, when a numbered-versus-slug mismatch
+went uncaught. Holding the schema in its own repo also gives the future
+curation and dispatch layers one shared definition to depend on, rather
+than each embedding its own copy. §req:modular-adoption
 
-**Why consume rather than own:** owning the contract made symphonize the
-de-facto kernel for every adopter, coupling them to its release cadence
-and full opinion. As a consumer, symphonize keeps its execution and
-curation opinions to itself while the shared contract lives in the
-kernel.
+**Why symphonize-specific:** the schema encodes symphonize's conventions
+and is consumed only by symphonize — not a general-purpose linter other
+projects adopt. If symphonize ever needs a different schema, it would plug
+a different one in on its own side; that seam stays unbuilt until a second
+schema exists.
 
-**Direction:** the kernel extraction is the first step toward decomposing
+**Direction:** the schema extraction is the first step toward decomposing
 symphonize into independently-adoptable layers — a curation layer and a
-dispatch layer over the shared kernel. The three-way split of today's
+dispatch layer over the shared schema. The three-way split of today's
 `CONVENTIONS.md` mirrors that layering: the structural slice anchors the
-kernel, the authoring methodology becomes curation's, and the process
+schema, the authoring methodology becomes curation's, and the process
 discipline becomes dispatch's. This section covers only the
-conventions-kernel boundary; the further splits await their own spec
+governance-schema boundary; the further splits await their own spec
 sections.
 
 **Tradeoff accepted:** a cross-repo dependency replaces an in-repo one.
-Symphonize's CI and scaffolding depend on a published kernel release. The
+Symphonize's CI and scaffolding depend on a published schema release. The
 pinned workflow ref and the plugin dependency range — both machine-checked
-— keep symphonize and the kernel on one version, with no bespoke marker to
+— keep symphonize and the schema on one version, with no bespoke marker to
 maintain.


### PR DESCRIPTION
## Summary

Records the conventions-kernel extraction in symphonize's own governance docs — the transition where symphonize stops *owning* the governance contract/scaffolder/enforcement and becomes a *consumer* of the conventions kernel (currently `bug-free-happiness`, specced in repentsinner/bug-free-happiness#12 and #13).

Documents the transition across the three docs by their roles: **why** in REQUIREMENTS, **what** in SPEC, **how/when** in ROADMAP.

## Changes

- **REQUIREMENTS.md** — `§req:modular-adoption`: the why. Symphonize bundles three separable capabilities (curation, dispatch, the conventions contract); adopters need them separately; the contract should be one shared source of truth; a contract and its linter drift when they live apart (the numbered-vs-slug bug). The conventions layer separates first because everything depends on it.
- **SPEC.md** — `§spec:conventions-kernel`: the what. Declarative end-state — a dedicated kernel repo owns the contract + scaffolder + enforcement; symphonize references the kernel's lint in CI, holds a materialized `CONVENTIONS.md` with a `contracts-version` marker, and defers `/init` to the kernel's scaffolder. Explicitly supersedes §spec:reusable-ci, §spec:dogfooding, §spec:self-contained-conventions, and the scaffolding ownership in §spec:project-scaffolding. Notes the broader curate/dispatch direction without spec'ing it yet.
- **ROADMAP.md** — the how/when. Four workstreams in build-dependency order: `consume-kernel-lint` → `adopt-kernel-conventions` → `adopt-kernel-scaffolder` → `remove-kernel-originals`. Each is annotated **blocked on the kernel shipping the relevant face** — the teardown comes last so consumption is verified before originals are removed (removing first would orphan adopters).

## Validation

markdownlint: 0 errors. Slug presence + status lines + cross-document references: PASS (no dangling refs). Vale (Requirements style): 0 errors, 0 warnings.

## Note

Spec-only / planning. The actual migration is the ROADMAP workstreams, all blocked on the kernel-side build (bug-free-happiness's own roadmap: the toggle inputs, contract, and scaffolder). This PR makes the transition auditable from symphonize's governance docs; it does not change behavior.
