### PR TITLE
feat: batch — repo-state reconciliation hook

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,27 +92,3 @@ and the duplicated `/init` scaffolding now served by the schema.
 deleted with no replacement file; `/symphonize:init` delegates to the
 schema's scaffolder; CI is green via the schema's workflow; `grep` finds
 no command referencing the removed `CONVENTIONS.md`.
-
-## Repo-state reconciliation hook
-
-Not blocked — symphonize-internal, no dependency on the schema work.
-
-### §road:reconcile-repo-state-hook
-
-Add a `UserPromptSubmit` hook — `hooks/hooks.json` plus a reconcile
-script referenced via `${CLAUDE_PLUGIN_ROOT}` — that runs a rate-limited
-read-only `git fetch` and injects divergence context (merged or closed
-PR for the current branch, branch behind `origin/main`, branch gone from
-the remote) each turn, staying silent on clean state and degrading to a
-no-op without git, `gh`, or network. §spec:repo-state-reconciliation
-
-**Verify:** Load the plugin locally (`claude --plugin-dir .`) in a git
-repo checked out to a branch with an open PR. From another terminal,
-merge that PR. Submit any prompt and confirm the turn's context reports
-the PR as merged. Reset to a clean, up-to-date branch and confirm the
-hook injects nothing and adds no perceptible latency. Run a prompt in a
-directory that is not a git repository and confirm the hook is a silent
-no-op — no error, the prompt proceeds. Remove `gh` from `PATH` and
-confirm the hook still reports branch ahead/behind from local refs
-without erroring. Submit two prompts within the rate-limit window and
-confirm only the first triggers a network fetch.

--- a/SPEC.md
+++ b/SPEC.md
@@ -810,7 +810,7 @@ merging unattended.
   are the only in-run protection. §req:quality-attributes
 
 ## Repo-state reconciliation hook §spec:repo-state-reconciliation
-*Status: not started*
+*Status: complete*
 
 An agent works from a snapshot of repo state taken when it last looked,
 and assumes it is the only actor. A human merges the open PR, force-pushes
@@ -821,33 +821,33 @@ governance loop's premise is that the docs and PRs reflect actual state
 (§req:success-criteria); an agent reasoning from stale state corrupts that
 premise from inside.
 
-Symphonize ships a Claude Code `UserPromptSubmit` hook in the plugin that
-reconciles the agent's view of repo state with the remote before each
-turn, and surfaces any divergence as conversation context.
+Symphonize ships a Claude Code `UserPromptSubmit` hook in the plugin
+(`hooks/hooks.json` registering `hooks/reconcile-repo-state.sh` via
+`${CLAUDE_PLUGIN_ROOT}`) that reconciles the agent's view of repo state with
+the remote before each turn, and surfaces any divergence as conversation
+context via `hookSpecificOutput.additionalContext`.
 
 ### Observable behavior
 
 - Before each user turn, the hook performs a **read-only** reconcile: a
-  rate-limited `git fetch`, then a comparison of the current branch
-  against its upstream and against `origin/main`, and of the branch's
-  associated pull request against its remote state.
+  rate-limited `git fetch --prune`, then a comparison of the current branch
+  against its upstream and `origin/main`, and of the branch's pull request
+  against its remote state.
 - The hook injects context **only when reality diverges** from the naive
   "nothing changed since I last looked" assumption — the current branch's
-  PR is merged or closed; the branch is behind `origin/main`; the branch
-  no longer exists on the remote. When nothing diverges, it injects
-  nothing.
-- The divergence is reported as a specific contradiction the agent
-  encounters at the point of use (e.g. "PR #118 for this branch is
-  MERGED"), not as an undifferentiated status dump.
-- The hook never blocks the prompt and never mutates the working tree or
-  the remote. It does not checkout, pull, rebase, or push. It reports;
-  the agent and user decide what to do.
-- The hook degrades to a silent no-op outside a git repository, when
-  `gh` is unavailable or unauthenticated, or when the network is
-  unreachable. Absence of remote state is never reported as a divergence.
-- The fetch is rate-limited: the hook skips the network round-trip when
-  one ran within a short window, so most turns add no latency. PR state
-  beyond that window is at most one window stale.
+  PR is merged or closed; the branch is behind `origin/main`; the branch no
+  longer exists on the remote. When nothing diverges, it injects nothing.
+- The divergence is reported as a specific contradiction at the point of use
+  (e.g. "PR #118 for this branch is MERGED"), not a status dump.
+- The hook never blocks the prompt and never mutates the working tree or the
+  remote (no checkout, pull, rebase, push). It reports; the agent and user
+  decide.
+- The hook degrades to a silent no-op outside a git repository, in detached
+  HEAD, when `gh` is unavailable or unauthenticated, or when the network is
+  unreachable. Absence of remote state is never reported as divergence.
+- The fetch is rate-limited via a per-repo stamp file: the hook skips the
+  network round-trip when one ran within a short window (default 300s), so
+  most turns add no latency. PR state is at most one window stale.
 
 ### Why a hook, not an instruction
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Reconcile repo state with the remote before each turn; inject context only on divergence.",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/reconcile-repo-state.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/reconcile-repo-state.sh
+++ b/hooks/reconcile-repo-state.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Symphonize repo-state reconciliation hook (UserPromptSubmit).
+#
+# Before each turn, reconcile the agent's view of the repo with the remote and
+# inject context ONLY when reality diverges from the naive "nothing changed
+# since I last looked" assumption: the current branch's PR is merged/closed,
+# the branch is behind origin/main, or the branch is gone from the remote.
+#
+# Contract (see SPEC.md §spec:repo-state-reconciliation):
+#   - Read-only. Performs at most a rate-limited `git fetch`; never checks out,
+#     pulls, rebases, pushes, or mutates the working tree or remote.
+#   - Silent no-op outside a git repo, or when git/gh/network are unavailable.
+#     Absence of remote state is never reported as divergence.
+#   - Always exits 0. Never blocks the prompt. Emits nothing on clean state.
+#   - On divergence, prints a single JSON object on stdout:
+#       {"hookSpecificOutput":{"hookEventName":"UserPromptSubmit",
+#        "additionalContext":"..."}}
+#
+# Env overrides (testing / tuning):
+#   RECONCILE_STAMP_DIR          stamp directory (default $TMPDIR/symphonize-reconcile)
+#   RECONCILE_RATE_WINDOW_SECONDS  fetch rate-limit window (default 300)
+#   RECONCILE_FETCH_DISABLE=1    skip the network fetch entirely
+
+# Never let an unexpected failure surface; reconciliation is best-effort.
+set -u
+
+# Any failure short-circuits to a clean, silent exit.
+bail() { exit 0; }
+
+command -v git >/dev/null 2>&1 || bail
+command -v jq >/dev/null 2>&1 || bail
+
+payload="$(cat)"
+[ -n "$payload" ] || bail
+
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null)"
+[ -n "$cwd" ] || bail
+[ -d "$cwd" ] || bail
+
+# Must be inside a git work tree; otherwise silent no-op.
+git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1 || bail
+
+toplevel="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)" || bail
+[ -n "$toplevel" ] || bail
+
+branch="$(git -C "$cwd" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+# Detached HEAD: no branch to reconcile.
+[ -n "$branch" ] || bail
+
+# --- Rate-limited fetch ----------------------------------------------------
+# Stamp keyed by the repo's absolute toplevel path so distinct repos do not
+# share a window. Skip the fetch when a recent stamp exists.
+window="${RECONCILE_RATE_WINDOW_SECONDS:-300}"
+stamp_dir="${RECONCILE_STAMP_DIR:-${TMPDIR:-/tmp}/symphonize-reconcile}"
+# Hash the path with a portable tool; fall back to a sanitized path.
+if command -v shasum >/dev/null 2>&1; then
+  key="$(printf '%s' "$toplevel" | shasum | cut -d' ' -f1)"
+elif command -v sha1sum >/dev/null 2>&1; then
+  key="$(printf '%s' "$toplevel" | sha1sum | cut -d' ' -f1)"
+else
+  key="$(printf '%s' "$toplevel" | tr -c 'A-Za-z0-9' '_')"
+fi
+stamp="$stamp_dir/$key"
+
+should_fetch=1
+[ "${RECONCILE_FETCH_DISABLE:-0}" = "1" ] && should_fetch=0
+
+if [ "$should_fetch" = "1" ] && [ -f "$stamp" ]; then
+  now="$(date +%s 2>/dev/null || echo 0)"
+  stamp_mtime="$(stat -f %m "$stamp" 2>/dev/null || stat -c %Y "$stamp" 2>/dev/null || echo 0)"
+  age=$((now - stamp_mtime))
+  if [ "$age" -ge 0 ] && [ "$age" -lt "$window" ]; then
+    should_fetch=0
+  fi
+fi
+
+if [ "$should_fetch" = "1" ]; then
+  mkdir -p "$stamp_dir" 2>/dev/null || true
+  # Read-only: fetch updates remote-tracking refs only. Prune so deleted
+  # upstream branches register as gone. Ignore failures (offline, no remote).
+  if git -C "$cwd" fetch --quiet --prune origin >/dev/null 2>&1; then
+    : >"$stamp" 2>/dev/null || true
+  fi
+fi
+
+# --- Divergence detection --------------------------------------------------
+messages=()
+
+# 1. PR state for the current branch (requires gh, authenticated). Degrades
+#    silently when gh is absent or unauthenticated — never a divergence itself.
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  pr_json="$(gh pr view "$branch" --json state,number,url 2>/dev/null || true)"
+  if [ -n "$pr_json" ]; then
+    pr_state="$(printf '%s' "$pr_json" | jq -r '.state // empty' 2>/dev/null)"
+    pr_number="$(printf '%s' "$pr_json" | jq -r '.number // empty' 2>/dev/null)"
+    case "$pr_state" in
+      MERGED)
+        messages+=("PR #${pr_number} for this branch (\`${branch}\`) is MERGED on the remote. Work on this branch is already integrated; do not push further commits here or treat the PR as open.")
+        ;;
+      CLOSED)
+        messages+=("PR #${pr_number} for this branch (\`${branch}\`) is CLOSED (not merged) on the remote. Do not treat it as an open review surface.")
+        ;;
+    esac
+  fi
+fi
+
+# 2/3. Branch position relative to its upstream and to origin/main, using
+#      local remote-tracking refs (no network — works without gh).
+upstream="$(git -C "$cwd" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+if [ -n "$upstream" ]; then
+  # Upstream ref configured but missing locally after prune => branch gone.
+  if ! git -C "$cwd" rev-parse --verify --quiet "$upstream" >/dev/null 2>&1; then
+    messages+=("This branch's upstream (\`${upstream}\`) no longer exists on the remote. The branch was deleted upstream (likely after merge); pushing will recreate it.")
+  fi
+fi
+
+# Behind origin/main: commits on origin/main not reachable from HEAD. Only
+# meaningful when origin/main exists and is not the current branch itself.
+if git -C "$cwd" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  head_sha="$(git -C "$cwd" rev-parse HEAD 2>/dev/null || true)"
+  main_sha="$(git -C "$cwd" rev-parse origin/main 2>/dev/null || true)"
+  if [ -n "$head_sha" ] && [ "$head_sha" != "$main_sha" ]; then
+    behind="$(git -C "$cwd" rev-list --count "HEAD..origin/main" 2>/dev/null || echo 0)"
+    if [ "${behind:-0}" -gt 0 ]; then
+      messages+=("This branch is ${behind} commit(s) behind \`origin/main\`. Its base is stale; rebase or merge \`origin/main\` before relying on it being current.")
+    fi
+  fi
+fi
+
+# --- Emit ------------------------------------------------------------------
+# Clean state: emit nothing, inject no context.
+[ "${#messages[@]}" -eq 0 ] && bail
+
+context="Repo-state reconciliation detected divergence from your assumed state:"
+for m in "${messages[@]}"; do
+  context="${context}"$'\n'"- ${m}"
+done
+
+jq -nc --arg ctx "$context" \
+  '{hookSpecificOutput:{hookEventName:"UserPromptSubmit",additionalContext:$ctx}}'
+
+exit 0

--- a/hooks/reconcile-repo-state.test.sh
+++ b/hooks/reconcile-repo-state.test.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Unit tests for reconcile-repo-state.sh.
+#
+# Each test crafts a throwaway git repo in a temp dir, drives the hook with a
+# synthetic stdin payload, and asserts on stdout. `gh` is stubbed via PATH so
+# tests stay offline and deterministic. The rate-limit window and stamp dir are
+# overridden via env so the network fetch is skipped and timing is controllable.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/reconcile-repo-state.sh"
+
+pass=0
+fail=0
+
+# Shared scratch root, cleaned on exit.
+ROOT="$(mktemp -d)"
+trap 'rm -rf "$ROOT"' EXIT
+
+# run_hook CWD [EXTRA_PATH_DIR]
+# Feeds a minimal UserPromptSubmit payload on stdin. RECONCILE_FETCH_DISABLE=1
+# keeps every test offline; RECONCILE_RATE_WINDOW_SECONDS and stamp dir are set
+# per-test by callers as needed.
+run_hook() {
+  local cwd="$1"
+  local extra_path="${2:-}"
+  local path="$PATH"
+  if [ -n "$extra_path" ]; then
+    path="$extra_path:$PATH"
+  fi
+  printf '{"hook_event_name":"UserPromptSubmit","cwd":"%s","prompt":"hi"}' "$cwd" |
+    PATH="$path" \
+    RECONCILE_STAMP_DIR="$STAMP_DIR" \
+    "$HOOK"
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    pass=$((pass + 1))
+    echo "ok   - $label"
+  else
+    fail=$((fail + 1))
+    echo "FAIL - $label"
+    echo "       expected to find: $needle"
+    echo "       in: $haystack"
+  fi
+}
+
+assert_empty() {
+  local label="$1" haystack="$2"
+  if [ -z "$haystack" ]; then
+    pass=$((pass + 1))
+    echo "ok   - $label"
+  else
+    fail=$((fail + 1))
+    echo "FAIL - $label (expected empty output)"
+    echo "       got: $haystack"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    fail=$((fail + 1))
+    echo "FAIL - $label (did not expect to find: $needle)"
+    echo "       in: $haystack"
+  else
+    pass=$((pass + 1))
+    echo "ok   - $label"
+  fi
+}
+
+# Create a gh stub directory that responds with a canned PR state.
+# make_gh_stub DIR STATE   (STATE = MERGED | CLOSED | OPEN | NONE | UNAUTH)
+make_gh_stub() {
+  local dir="$1" state="$2"
+  mkdir -p "$dir"
+  cat >"$dir/gh" <<EOF
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "auth status")
+    if [ "$state" = "UNAUTH" ]; then exit 1; fi
+    exit 0 ;;
+esac
+# pr view / pr list
+if [ "$state" = "NONE" ]; then
+  exit 1
+fi
+if [ "$state" = "UNAUTH" ]; then
+  exit 1
+fi
+# Emit the requested --json field as a state string.
+echo '{"state":"$state","number":42,"url":"https://example/pr/42"}'
+exit 0
+EOF
+  chmod +x "$dir/gh"
+}
+
+# git wrapper that isolates from the user's global config and hooks
+# (e.g. a global commit-msg hook enforcing conventional commits).
+tgit() {
+  git -c core.hooksPath=/dev/null \
+      -c commit.gpgsign=false \
+      -c user.email=t@t.t \
+      -c user.name=t \
+      "$@"
+}
+
+# A fresh local+remote git pair. Echoes the work-tree path.
+# make_repo NAME
+make_repo() {
+  local name="$1"
+  local remote="$ROOT/$name-remote.git"
+  local work="$ROOT/$name"
+  tgit init --quiet --bare "$remote"
+  tgit init --quiet "$work"
+  tgit -C "$work" checkout -q -b main
+  echo "seed" >"$work/file"
+  tgit -C "$work" add file
+  tgit -C "$work" commit --quiet -m "seed"
+  tgit -C "$work" remote add origin "$remote"
+  tgit -C "$work" push --quiet -u origin main
+  echo "$work"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: not a git repo -> silent no-op
+# ---------------------------------------------------------------------------
+STAMP_DIR="$ROOT/stamps1"
+NON_GIT="$ROOT/plain"
+mkdir -p "$NON_GIT"
+out="$(RECONCILE_FETCH_DISABLE=1 run_hook "$NON_GIT")"
+assert_empty "non-git directory is a silent no-op" "$out"
+
+# ---------------------------------------------------------------------------
+# Test 2: clean, up-to-date branch -> injects nothing
+# ---------------------------------------------------------------------------
+STAMP_DIR="$ROOT/stamps2"
+work="$(make_repo clean)"
+ghdir="$ROOT/gh-none"
+make_gh_stub "$ghdir" NONE
+out="$(RECONCILE_FETCH_DISABLE=1 run_hook "$work" "$ghdir")"
+assert_empty "clean up-to-date branch injects nothing" "$out"
+
+# ---------------------------------------------------------------------------
+# Test 3: branch behind origin/main -> reports behind
+# ---------------------------------------------------------------------------
+STAMP_DIR="$ROOT/stamps3"
+work="$(make_repo behind)"
+# Advance origin/main from a second clone, then update local remote-tracking ref.
+clone="$ROOT/behind-clone"
+tgit clone --quiet "$ROOT/behind-remote.git" "$clone"
+echo "more" >"$clone/file2"
+tgit -C "$clone" add file2
+tgit -C "$clone" commit --quiet -m "advance main"
+tgit -C "$clone" push --quiet origin main
+# Put the local repo on a feature branch behind main, fetch so origin/main moves.
+tgit -C "$work" checkout -q -b feature
+tgit -C "$work" fetch --quiet origin
+ghdir="$ROOT/gh-none3"
+make_gh_stub "$ghdir" NONE
+out="$(RECONCILE_FETCH_DISABLE=1 run_hook "$work" "$ghdir")"
+assert_contains "branch behind origin/main is reported" "$out" "behind"
+assert_contains "behind report names origin/main" "$out" "origin/main"
+
+# ---------------------------------------------------------------------------
+# Test 4: branch gone from remote -> reports gone
+# ---------------------------------------------------------------------------
+STAMP_DIR="$ROOT/stamps4"
+work="$(make_repo gone)"
+tgit -C "$work" checkout -q -b throwaway
+tgit -C "$work" push --quiet -u origin throwaway
+# Delete the branch on the remote, then prune so the upstream ref is "gone".
+tgit -C "$work" push --quiet origin --delete throwaway
+tgit -C "$work" fetch --quiet --prune origin
+ghdir="$ROOT/gh-none4"
+make_gh_stub "$ghdir" NONE
+out="$(RECONCILE_FETCH_DISABLE=1 run_hook "$work" "$ghdir")"
+assert_contains "branch gone from remote is reported" "$out" "no longer exists"
+
+# ---------------------------------------------------------------------------
+# Test 5: PR merged -> reports merged (with gh)
+# ---------------------------------------------------------------------------
+STAMP_DIR="$ROOT/stamps5"
+work="$(make_repo prmerged)"
+tgit -C "$work" checkout -q -b pr-branch
+tgit -C "$work" push --quiet -u origin pr-branch
+ghdir="$ROOT/gh-merged"
+make_gh_stub "$ghdir" MERGED
+out="$(RECONCILE_FETCH_DISABLE=1 run_hook "$work" "$ghdir")"
+assert_contains "merged PR is reported" "$out" "MERGED"
+assert_contains "merged PR output is valid hook JSON" "$out" "UserPromptSubmit"
+
+# ---------------------------------------------------------------------------
+# Test 6: PR open + clean branch -> injects nothing
+# ---------------------------------------------------------------------------
+STAMP_DIR="$ROOT/stamps6"
+work="$(make_repo propen)"
+tgit -C "$work" checkout -q -b open-branch
+tgit -C "$work" push --quiet -u origin open-branch
+ghdir="$ROOT/gh-open"
+make_gh_stub "$ghdir" OPEN
+out="$(RECONCILE_FETCH_DISABLE=1 run_hook "$work" "$ghdir")"
+assert_empty "open PR on clean branch injects nothing" "$out"
+
+# ---------------------------------------------------------------------------
+# Test 7: gh absent -> still reports ahead/behind from local refs, no error
+# ---------------------------------------------------------------------------
+STAMP_DIR="$ROOT/stamps7"
+work="$(make_repo noghbehind)"
+clone="$ROOT/nogh-clone"
+tgit clone --quiet "$ROOT/noghbehind-remote.git" "$clone"
+echo "x" >"$clone/file2"
+tgit -C "$clone" add file2
+tgit -C "$clone" commit --quiet -m "advance"
+tgit -C "$clone" push --quiet origin main
+tgit -C "$work" checkout -q -b feat2
+tgit -C "$work" fetch --quiet origin
+# Build a PATH with only the dirs needed for git, deliberately omitting gh.
+NOGH_BIN="$ROOT/nogh-bin"
+mkdir -p "$NOGH_BIN"
+for tool in git jq cat printf date stat mkdir tr cut shasum sha1sum \
+            mktemp dirname basename grep sed env bash sh head find; do
+  src="$(command -v "$tool" 2>/dev/null)" && ln -sf "$src" "$NOGH_BIN/$tool"
+done
+out="$(printf '{"hook_event_name":"UserPromptSubmit","cwd":"%s","prompt":"hi"}' "$work" |
+  PATH="$NOGH_BIN" RECONCILE_STAMP_DIR="$STAMP_DIR" RECONCILE_FETCH_DISABLE=1 "$HOOK")"
+rc=$?
+assert_contains "gh absent still reports behind" "$out" "behind"
+if [ "$rc" -eq 0 ]; then
+  pass=$((pass + 1)); echo "ok   - gh absent exits 0"
+else
+  fail=$((fail + 1)); echo "FAIL - gh absent exits 0 (got $rc)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: rate limit -> second call within window does not fetch
+# ---------------------------------------------------------------------------
+STAMP_DIR="$ROOT/stamps8"
+work="$(make_repo ratelimit)"
+ghdir="$ROOT/gh-none8"
+make_gh_stub "$ghdir" NONE
+# First call: fetch enabled, large window, against the real (bare) remote.
+printf '{"hook_event_name":"UserPromptSubmit","cwd":"%s","prompt":"hi"}' "$work" |
+  PATH="$ghdir:$PATH" RECONCILE_STAMP_DIR="$STAMP_DIR" \
+  RECONCILE_RATE_WINDOW_SECONDS=3600 "$HOOK" >/dev/null
+stamp="$(find "$STAMP_DIR" -type f | head -n1)"
+if [ -n "$stamp" ]; then
+  pass=$((pass + 1)); echo "ok   - first call creates a fetch stamp"
+else
+  fail=$((fail + 1)); echo "FAIL - first call creates a fetch stamp"
+fi
+mt1="$(stat -f %m "$stamp" 2>/dev/null || stat -c %Y "$stamp")"
+# Second call within the window: stamp mtime must be unchanged (no fetch).
+printf '{"hook_event_name":"UserPromptSubmit","cwd":"%s","prompt":"hi"}' "$work" |
+  PATH="$ghdir:$PATH" RECONCILE_STAMP_DIR="$STAMP_DIR" \
+  RECONCILE_RATE_WINDOW_SECONDS=3600 "$HOOK" >/dev/null
+mt2="$(stat -f %m "$stamp" 2>/dev/null || stat -c %Y "$stamp")"
+if [ "$mt1" = "$mt2" ]; then
+  pass=$((pass + 1)); echo "ok   - second call within window skips fetch (stamp unchanged)"
+else
+  fail=$((fail + 1)); echo "FAIL - second call within window skips fetch (stamp changed $mt1 -> $mt2)"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Implements `§road:reconcile-repo-state-hook` → `§spec:repo-state-reconciliation` (spec #120, roadmap #121).

## Workstream

- **§road:reconcile-repo-state-hook** — `feat(hooks): add repo-state reconciliation UserPromptSubmit hook`

## What ships

- `hooks/hooks.json` — registers the hook on `UserPromptSubmit` via `${CLAUDE_PLUGIN_ROOT}` (auto-discovered; no plugin.json change).
- `hooks/reconcile-repo-state.sh` — rate-limited read-only `git fetch --prune`, then injects `hookSpecificOutput.additionalContext` **only on divergence**: current branch's PR merged/closed, branch behind `origin/main`, or upstream gone. Silent no-op without git/jq/gh/network or in detached HEAD. Never mutates tree or remote.
- `hooks/reconcile-repo-state.test.sh` — 12 cases, all green.

## Verify (ROADMAP acceptance criteria) — covered by the test suite

| Criterion | Test |
|---|---|
| Merged PR reported mid-session | `merged PR is reported` + `valid hook JSON` |
| Clean up-to-date branch → nothing | `clean up-to-date branch injects nothing`, `open PR on clean branch injects nothing` |
| Non-git dir → silent no-op | `non-git directory is a silent no-op` |
| `gh` absent → still reports ahead/behind, exits 0 | `gh absent still reports behind`, `gh absent exits 0` |
| Rate-limit window | `first call creates a fetch stamp`, `second call within window skips fetch` |
| Branch gone from remote | `branch gone from remote is reported` |

Run `bash hooks/reconcile-repo-state.test.sh` → `passed: 12  failed: 0` (verified under macOS bash 3.2). `hooks.json` validates as JSON; markdownlint clean on governance files.

## Live test path

`claude --plugin-dir .` in a repo on a branch with an open PR; merge the PR from another terminal; next prompt's context reports it MERGED. Reset clean → silent.

## Notes

- Adds `jq` as a soft dependency (used to parse hook stdin and emit escaped JSON); absent `jq` → silent no-op.
- `/security-review` ran clean (read-only; all dynamic values quoted args or `jq --arg`-escaped). `shellcheck` not installed in this environment — manual review only.
- Recovered delivery: the batch agent implemented and verified but exited before pushing; commits/PR finalized from its worktree.

> Run `/review --comment` to post code-quality findings as PR comments.