### PR TITLE
docs(roadmap): triage #125 — schedule stat probe-order fix for reconcile hook

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,3 +92,19 @@ and the duplicated `/init` scaffolding now served by the schema.
 deleted with no replacement file; `/symphonize:init` delegates to the
 schema's scaffolder; CI is green via the schema's workflow; `grep` finds
 no command referencing the removed `CONVENTIONS.md`.
+
+## Repo-state reconciliation hook — stat probe order
+
+### §road:fix-stat-probe-order
+
+Reorder the `stat` mtime probe in `hooks/reconcile-repo-state.sh` to try the
+GNU form (`stat -c %Y`) before the BSD form (`stat -f %m`), so GNU/Linux hits
+the working path and exits 0 before the BSD fallback pollutes stdout and
+crashes the rate-limit read under `set -u`. Reported in #125.
+§spec:repo-state-reconciliation
+
+**Verify:** On GNU/Linux, trigger a `UserPromptSubmit` with an existing stamp
+file inside the rate-limit window; the hook emits no `File: unbound variable`
+error and skips the fetch silently. On macOS, the same scenario still
+rate-limits correctly. `stat -c %Y "$stamp"` resolves the mtime on Linux
+without falling through to the BSD form.


### PR DESCRIPTION
Triage of #125.

**Classification:** Bug → ROADMAP workstream.

The `reconcile-repo-state.sh` UserPromptSubmit hook crashes with `File: unbound variable` every turn on GNU/Linux. Line 71 probes `stat -f %m` (BSD form) first; on GNU coreutils `-f` means `--file-system`, so `%m` is parsed as a filename. The probe fails (exit 1) but still dumps a filesystem block to stdout, so the `|| stat -c %Y` fallback also runs and concatenates output. The arithmetic on line 72 then chokes on the `File` bareword under `set -u`, silently halting reconciliation.

This is an implementation defect against the already-complete `§spec:repo-state-reconciliation`, which specifies silent no-op degradation — not a design gap. Routed to ROADMAP as `§road:fix-stat-probe-order`.

Adds the workstream only; the fix lands via `/next`.