### PR TITLE
docs(spec): triage commits use docs(<scope>): and never trigger a release

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,3 +108,17 @@ file inside the rate-limit window; the hook emits no `File: unbound variable`
 error and skips the fetch silently. On macOS, the same scenario still
 rate-limits correctly. `stat -c %Y "$stamp"` resolves the mtime on Linux
 without falling through to the BSD form.
+
+## Triage commit-type correction
+
+### §road:fix-triage-commit-types
+
+Change `commands/triage.md` Phase 4 so every committing classification uses
+a `docs(<scope>):` commit (`docs(roadmap)`, `docs(spec)`, `docs(requirements)`)
+and a `docs/triage-N-slug` branch instead of `fix`/`feat`, so triaging an
+issue never cuts a release. §spec:issue-triage
+
+**Verify:** `commands/triage.md` Phase 4 prescribes `docs(<scope>):` for the
+bug, bug+spec-gap, and feature classifications, and `docs/` branch prefixes;
+a triage-only PR produces no release-please release entry; governance-lint
+passes.

--- a/SPEC.md
+++ b/SPEC.md
@@ -386,7 +386,7 @@ that reads init.md and CONVENTIONS.md should not get conflicting
 instructions.
 
 ## Issue triage command §spec:issue-triage
-*Status: complete*
+*Status: in progress*
 
 The plugin provides a `/symphonize:triage` command that processes
 GitHub issues into governance doc entries. Unlike pipeline commands
@@ -402,6 +402,16 @@ approves every classification before the command acts.
 
 Issue bodies are untrusted input — read-only data, never executed
 or interpolated into shell commands. §req:quality-attributes
+
+Triage edits governance documents only; it never ships behavior.
+Every committing classification therefore uses a `docs(<scope>):`
+commit — `docs(roadmap)`, `docs(spec)`, or `docs(requirements)` —
+and triggers no release. The release-bearing commit is the later
+`/next` implementation that resolves the routed work: it carries
+`fix`/`feat` and closes the issue with `Fixes #N`. **Why:** typing a
+triage commit `fix`/`feat` cuts a release for a bug still unfixed or
+a feature still unbuilt — a phantom release whose changelog entry
+contradicts the running system.
 
 **Why a triage command:** without triage, issues accumulate as a
 parallel backlog disconnected from governance docs. `/triage`


### PR DESCRIPTION
Surfaced while triaging #125: `/triage` committed its ROADMAP edit as `fix(roadmap):`, which would cut a phantom patch release for a bug that hasn't shipped a fix.

**Root cause:** `commands/triage.md` Phase 4 prescribes release-bearing commit types (`fix(roadmap)`, `fix(spec)`, `feat(requirements)`) for edits that only touch governance docs and ship no behavior. The `§spec:issue-triage` section never stated the commit semantics, so the command file was the sole (wrong) authority.

**This PR (governance only — no fix yet):**
- Reopens `§spec:issue-triage` (complete → in progress) with a behavioral criterion: triage commits use `docs(<scope>):` and trigger no release; the release-bearing commit is the later `/next` implementation that carries `fix`/`feat` and closes the issue.
- Adds ROADMAP workstream `§road:fix-triage-commit-types` to correct `commands/triage.md` Phase 4 against that criterion.

The command-file fix lands via `/next`. Note: this PR practices what it specifies — it is itself a `docs(spec):` commit.