### PR TITLE
feat: batch — fix Linux stat probe crash and triage commit types

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,33 +92,3 @@ and the duplicated `/init` scaffolding now served by the schema.
 deleted with no replacement file; `/symphonize:init` delegates to the
 schema's scaffolder; CI is green via the schema's workflow; `grep` finds
 no command referencing the removed `CONVENTIONS.md`.
-
-## Repo-state reconciliation hook — stat probe order
-
-### §road:fix-stat-probe-order
-
-Reorder the `stat` mtime probe in `hooks/reconcile-repo-state.sh` to try the
-GNU form (`stat -c %Y`) before the BSD form (`stat -f %m`), so GNU/Linux hits
-the working path and exits 0 before the BSD fallback pollutes stdout and
-crashes the rate-limit read under `set -u`. Reported in #125.
-§spec:repo-state-reconciliation
-
-**Verify:** On GNU/Linux, trigger a `UserPromptSubmit` with an existing stamp
-file inside the rate-limit window; the hook emits no `File: unbound variable`
-error and skips the fetch silently. On macOS, the same scenario still
-rate-limits correctly. `stat -c %Y "$stamp"` resolves the mtime on Linux
-without falling through to the BSD form.
-
-## Triage commit-type correction
-
-### §road:fix-triage-commit-types
-
-Change `commands/triage.md` Phase 4 so every committing classification uses
-a `docs(<scope>):` commit (`docs(roadmap)`, `docs(spec)`, `docs(requirements)`)
-and a `docs/triage-N-slug` branch instead of `fix`/`feat`, so triaging an
-issue never cuts a release. §spec:issue-triage
-
-**Verify:** `commands/triage.md` Phase 4 prescribes `docs(<scope>):` for the
-bug, bug+spec-gap, and feature classifications, and `docs/` branch prefixes;
-a triage-only PR produces no release-please release entry; governance-lint
-passes.

--- a/SPEC.md
+++ b/SPEC.md
@@ -386,7 +386,7 @@ that reads init.md and CONVENTIONS.md should not get conflicting
 instructions.
 
 ## Issue triage command §spec:issue-triage
-*Status: in progress*
+*Status: complete*
 
 The plugin provides a `/symphonize:triage` command that processes
 GitHub issues into governance doc entries. Unlike pipeline commands

--- a/commands/triage.md
+++ b/commands/triage.md
@@ -154,23 +154,28 @@ proceeding.
 
 ## Phase 4: Commit and push
 
-1. Create a feature branch from `origin/main`. Use the conventional
-   commit type matching the classification:
+1. Create a feature branch from `origin/main`. Triage edits
+   governance documents only and ships no behavior, so every
+   committing classification uses a `docs/` branch:
 
-   - Bug → `fix/triage-N-slug`
-   - Feature → `feat/triage-N-slug`
+   - Bug → `docs/triage-N-slug`
+   - Feature → `docs/triage-N-slug`
 
    ```bash
-   git checkout -b <type>/triage-<issue-number>-<slug> origin/main
+   git checkout -b docs/triage-<issue-number>-<slug> origin/main
    ```
 
 2. Write the governance file updates.
 
-3. Commit with conventional format:
+3. Commit with conventional format. Triage commits never cut a
+   release — they use `docs(<scope>):`, scoped to the governance
+   file written. The release-bearing commit is the later `/next`
+   implementation carrying `fix`/`feat` and closing the issue with
+   `Fixes #N`.
 
-   - Bug → `fix(roadmap): triage #N — short description`
-   - Bug + spec gap → `fix(spec): triage #N — short description`
-   - Feature → `feat(requirements): triage #N — short description`
+   - Bug → `docs(roadmap): triage #N — short description`
+   - Bug + spec gap → `docs(spec): triage #N — short description`
+   - Feature → `docs(requirements): triage #N — short description`
    - Feedback/out-of-scope → no commit (comment only)
 
 4. Push and open a PR. The PR body cites the source issue:

--- a/hooks/reconcile-repo-state.sh
+++ b/hooks/reconcile-repo-state.sh
@@ -68,7 +68,11 @@ should_fetch=1
 
 if [ "$should_fetch" = "1" ] && [ -f "$stamp" ]; then
   now="$(date +%s 2>/dev/null || echo 0)"
-  stamp_mtime="$(stat -f %m "$stamp" 2>/dev/null || stat -c %Y "$stamp" 2>/dev/null || echo 0)"
+  # Probe the GNU form first: `stat -c %Y` fails cleanly (no stdout) on BSD/macOS
+  # and falls through to `stat -f %m`. The reverse order is unsafe — GNU `stat -f`
+  # means --file-system and prints a block to stdout while exiting non-zero, which
+  # leaks into the substitution and crashes the arithmetic below under set -u (#125).
+  stamp_mtime="$(stat -c %Y "$stamp" 2>/dev/null || stat -f %m "$stamp" 2>/dev/null || echo 0)"
   age=$((now - stamp_mtime))
   if [ "$age" -ge 0 ] && [ "$age" -lt "$window" ]; then
     should_fetch=0

--- a/hooks/reconcile-repo-state.test.sh
+++ b/hooks/reconcile-repo-state.test.sh
@@ -264,6 +264,69 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 9: GNU `stat` form is probed before BSD (regression for #125)
+# ---------------------------------------------------------------------------
+# On GNU coreutils, `stat -f` means --file-system and `%m` is a bare filename:
+# the probe exits non-zero but still prints a filesystem block to stdout. If the
+# hook probes the BSD form (`stat -f %m`) first, that block leaks into the
+# command substitution, the `|| stat -c %Y` fallback also runs, and the mtime
+# read becomes a multi-word string. Arithmetic on it under `set -u` then throws
+# `File: unbound variable`. The fix probes the GNU form (`stat -c %Y`) first.
+#
+# We stub `stat` on PATH to emulate GNU coreutils regardless of host platform:
+#   stat -c %Y FILE  -> prints the mtime, exits 0
+#   stat -f %m  FILE -> prints a filesystem block, exits 1 (GNU --file-system)
+STAMP_DIR="$ROOT/stamps9"
+work="$(make_repo gnustat)"
+ghdir="$ROOT/gh-none9"
+make_gh_stub "$ghdir" NONE
+
+GNUSTAT_BIN="$ROOT/gnustat-bin"
+mkdir -p "$GNUSTAT_BIN"
+# Symlink the real tools the hook needs, but shadow `stat` with a GNU emulator.
+for tool in git jq cat printf date mkdir tr cut shasum sha1sum \
+            mktemp dirname basename grep sed env bash sh head find; do
+  src="$(command -v "$tool" 2>/dev/null)" && ln -sf "$src" "$GNUSTAT_BIN/$tool"
+done
+REAL_STAT="$(command -v stat)"
+cat >"$GNUSTAT_BIN/stat" <<EOF
+#!/usr/bin/env bash
+# GNU coreutils emulator: -c %Y works; -f %m is --file-system (prints a block,
+# exits non-zero against a regular file).
+if [ "\$1" = "-c" ]; then
+  exec "$REAL_STAT" -f %m "\$3"
+fi
+if [ "\$1" = "-f" ]; then
+  echo "  File: \"\$3\""
+  echo "    ID: 0 Namelen: 255 Type: apfs"
+  exit 1
+fi
+exec "$REAL_STAT" "\$@"
+EOF
+chmod +x "$GNUSTAT_BIN/stat"
+
+# Pre-create a stamp inside the rate-limit window so the hook reads its mtime.
+# The hook keys the stamp on the repo's resolved toplevel (which may differ from
+# $work — e.g. /tmp vs /private/tmp on macOS), so derive the key the same way.
+mkdir -p "$STAMP_DIR"
+stamp_top="$(tgit -C "$work" rev-parse --show-toplevel)"
+key="$(printf '%s' "$stamp_top" | shasum | cut -d' ' -f1)"
+: >"$STAMP_DIR/$key"
+
+out="$(printf '{"hook_event_name":"UserPromptSubmit","cwd":"%s","prompt":"hi"}' "$work" |
+  PATH="$ghdir:$GNUSTAT_BIN" RECONCILE_STAMP_DIR="$STAMP_DIR" \
+  RECONCILE_RATE_WINDOW_SECONDS=3600 "$HOOK" 2>&1)"
+rc=$?
+assert_not_contains "GNU stat: no 'File: unbound variable' crash" "$out" "unbound variable"
+assert_not_contains "GNU stat: filesystem block does not leak to output" "$out" "Namelen"
+assert_empty "GNU stat: clean rate-limited turn injects nothing" "$out"
+if [ "$rc" -eq 0 ]; then
+  pass=$((pass + 1)); echo "ok   - GNU stat: hook exits 0"
+else
+  fail=$((fail + 1)); echo "FAIL - GNU stat: hook exits 0 (got $rc)"
+fi
+
+# ---------------------------------------------------------------------------
 echo
 echo "passed: $pass  failed: $fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Batch of two independent, user-requested vertical slices. Each is its own conventional commit with its workstream removed from ROADMAP.

## Workstreams

- **`fix(hooks): probe GNU stat form before BSD in reconcile hook`** (`§road:fix-stat-probe-order`, §spec:repo-state-reconciliation). The reconcile hook crashed every turn on GNU/Linux with `File: unbound variable` — the BSD `stat -f %m` probe ran first, and on GNU coreutils `-f` means `--file-system`, leaking a filesystem block into the command substitution. Reordered to probe the GNU form first; macOS falls through cleanly to the BSD form. Adds a regression test emulating GNU coreutils via a PATH stub. **Fixes #125.**
- **`fix(commands): triage commits use docs(<scope>): types`** (`§road:fix-triage-commit-types`, §spec:issue-triage). `/triage` Phase 4 prescribed release-bearing `fix`/`feat` commit (and branch) types for edits that only touch governance docs — cutting a phantom release for a bug still unfixed or a feature still unbuilt. Now prescribes `docs(<scope>):` commits and `docs/` branches. The release-bearing commit is the later `/next` implementation.

Governance bookkeeping: both workstreams removed from ROADMAP.md; `§spec:issue-triage` status returned to `complete`.

## Verification

- Hook test suite: 16/16 pass, including 4 new GNU-stat regression tests (no `File: unbound variable`, no filesystem-block leak, clean rate-limited turn, exit 0).
- markdownlint clean on the CI-globbed governance docs (SPEC.md, ROADMAP.md).
- `/security-review`: no findings.

> Run /review --comment to post code-quality findings as PR comments.