### PR TITLE
chore: ignore .claude scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .symphonize-progress.local.md
+.claude/


### PR DESCRIPTION
Post-merge cleanup. The untracked `.claude/` directory (Claude Code scratch: worktrees, session settings, memory, progress files) was tripping the `/symphonize:clean --full` dirty-state guard every run. Ignore it so it stays out of `git status` and the guard.

`.symphonize-progress.local.md` was already ignored; this adds the directory that holds the rest of the local agent state.