### PR TITLE
ci: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -13,7 +13,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}

--- a/.github/workflows/governance-lint.yml
+++ b/.github/workflows/governance-lint.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run Vale prose linter
         if: hashFiles('.vale.ini') != ''

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,13 +13,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -11,7 +11,7 @@ jobs:
   update-major-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Move floating major tag
         run: |


### PR DESCRIPTION
Bumps pinned GitHub Actions to their current major versions across the workflows:

- `actions/checkout` v4 → v5
- `actions/create-github-app-token` v1 → v3
- `googleapis/release-please-action` v4 → v5

Touches `auto-merge-release.yml`, `governance-lint.yml`, `release-please.yml`, and `update-major-tag.yml`. No behavioral changes — version bumps only. CI (governance-lint) exercises the updated `checkout` action on this PR.