### PR TITLE
ci: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Keep the GitHub Actions pinned in .github/workflows current. These
+  # workflow files are also the templates /symphonize:init copies into
+  # consuming repos, so keeping them fresh here keeps new scaffolds from
+  # shipping stale action versions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Adds `.github/dependabot.yml` for the `github-actions` ecosystem (weekly).

**Why:** symphonize's `.github/workflows/*` are dual-purpose — they're this repo's CI *and* the templates `/symphonize:init` copies into consuming repos. With no automated freshness mechanism, pinned actions rot in place (as #134 caught manually: checkout@v4, create-github-app-token@v1, release-please-action@v4 had all fallen a major behind). Dependabot keeps the source current, so the plugin bundle — and therefore every new scaffold — ships current action versions. This is the standing replacement for the one-time manual bump in #134.

Scoped to keeping symphonize's own source fresh (problem A: 'don't init the past'). Propagating freshness to already-scaffolded consumer repos is tracked separately via the init-scaffolding change.