### PR TITLE
docs(roadmap): realign schema workstreams to in-repo notation decomposition

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,74 +24,26 @@ no stop-hook directives fire from ralph-loop. Finally,
 return no matches in active code paths (CHANGELOG.md may retain
 historical references).
 
-## Consume the schema's enforcement workflow
+## Relocate CONVENTIONS.md content
 
-Blocked — depends on the schema's `governance-lint.yml` reaching a
-referenceable major tag. Unblocked when it ships.
-
-### §road:consume-schema-lint
-
-Point `.github/workflows/ci.yml` at the schema's `governance-lint.yml`,
-retiring the embedded reusable workflow once CI is green.
-§spec:governance-schema
-
-**Verify:** `ci.yml` calls the schema's `governance-lint.yml@<major>`; CI
-passes on this repo's governance files; symphonize no longer hosts its own
-`governance-lint.yml` as the source of truth.
-
-## Relocate CONVENTIONS.md content into commands
-
-Not blocked — symphonize-internal, can proceed before the schema ships.
-Prepares `CONVENTIONS.md` for deletion (§road:remove-schema-originals);
-the structural grammar needs no replacement file (the schema's linter
-enforces it), so only the methodology and process content must move.
+Not blocked — proceeds against today's command files, which become the
+compose and conduct plugins. Implements the content split in
+§spec:governance-schema ("Where today's CONVENTIONS.md content goes"): the
+structural grammar needs no replacement file because notation's linter is
+its executable form, so only the methodology and process content move.
 
 ### §road:relocate-conventions-content
 
-Move `CONVENTIONS.md`'s authoring methodology inline into the curation
-commands and its process discipline into the dispatch commands and
-`protocols/batch-agent.md`, repointing each command that reads
-`CONVENTIONS.md`. §spec:governance-schema
-
-**Verify:** `discover`/`plan`/`roadmap` carry their methodology inline;
-`next`/`orchestrate`/`clean` and `batch-agent.md` carry the process
-discipline; no command depends on a `CONVENTIONS.md` section slated for
-deletion; governance-lint passes.
-
-## Adopt the schema's scaffolder
-
-Blocked — depends on the schema's scaffolder being installable as a
-plugin. Unblocked when it ships.
-
-### §road:adopt-schema-scaffolder
-
-Make `/symphonize:init` defer to the schema's scaffolder and declare a
-plugin dependency on the schema in symphonize's plugin manifest.
+Move `CONVENTIONS.md`'s authoring methodology inline into the compose
+commands (`discover`/`plan`/`roadmap`) and its process discipline into the
+conduct commands (`next`/`orchestrate`/`clean`) and
+`protocols/batch-agent.md`, then delete `CONVENTIONS.md`.
 §spec:governance-schema
 
-**Verify:** symphonize's `.claude-plugin` manifest declares a dependency
-on the schema's plugin; `/symphonize:init` no longer carries its own
-governance-file and CONVENTIONS scaffolding logic; a scaffolded test repo
-references a coherent schema.
-
-## Remove symphonize's superseded originals
-
-Blocked — depends on §road:consume-schema-lint,
-§road:adopt-schema-scaffolder, and §road:relocate-conventions-content.
-Unblocked when consumption is verified end-to-end and `CONVENTIONS.md`'s
-content has moved; removing originals first would orphan adopters or
-strand command references.
-
-### §road:remove-schema-originals
-
-Delete symphonize's embedded `governance-lint.yml`, its `CONVENTIONS.md`,
-and the duplicated `/init` scaffolding now served by the schema.
-§spec:governance-schema
-
-**Verify:** no embedded `governance-lint.yml` remains; `CONVENTIONS.md` is
-deleted with no replacement file; `/symphonize:init` delegates to the
-schema's scaffolder; CI is green via the schema's workflow; `grep` finds
-no command referencing the removed `CONVENTIONS.md`.
+**Verify:** `discover`/`plan`/`roadmap` carry the authoring methodology
+inline; `next`/`orchestrate`/`clean` and `batch-agent.md` carry the process
+discipline; `CONVENTIONS.md` is deleted with no command referencing it;
+governance-lint passes.
 
 ## Scaffolding freshness
 
@@ -104,6 +56,6 @@ delegate-freshness contract in `commands/init.md`. §spec:scaffold-freshness
 **Verify:** a repo scaffolded by `/symphonize:init` contains a
 `.github/dependabot.yml` enabling weekly `github-actions` updates;
 `commands/init.md` and §spec:scaffold-freshness agree on the contract;
-governance-lint passes. If §road:adopt-schema-scaffolder has landed first,
-the dependabot scaffolding lives in the schema's scaffolder, not
-`commands/init.md`.
+governance-lint passes. The dependabot scaffolding lives with the `init`
+scaffolder — `commands/init.md` today, the notation plugin once the
+decomposition (§spec:governance-schema) builds it out.

--- a/SPEC.md
+++ b/SPEC.md
@@ -143,9 +143,9 @@ worse. A `/doctor`-style command, if built, belongs to governance-document
 drift (status-line validity, dangling slugs, docs-versus-repo-state),
 where symphonize is the source of truth — not to action versions.
 
-When scaffolding ownership migrates to the schema's scaffolder
-(§spec:governance-schema, §road:adopt-schema-scaffolder), this freshness
-contract migrates with it. §req:modular-adoption
+The `init` scaffolder becomes the notation plugin's under the plugin
+decomposition (§spec:governance-schema); this freshness contract is
+notation's and moves with it. §req:modular-adoption
 
 ## Dogfooding §spec:dogfooding
 *Status: complete*


### PR DESCRIPTION
Follows the merge of #123 (plugin decomposition: notation/compose/conduct, schema folds **in-repo**). #123's reversal — notation keeps `governance-lint.yml`, the grammar, and the `init` scaffolder rather than moving them to an external repo — mooted every workstream premised on *consuming an external schema*, and left dangling references behind.

## ROADMAP

**Deleted (moot — no external schema to consume):**
- `§road:consume-schema-lint` — symphonize's own `governance-lint.yml` *is* notation's; nothing to point `ci.yml` at externally.
- `§road:adopt-schema-scaffolder` — the `init` scaffolder stays as notation's; no external scaffolder to defer to.
- `§road:remove-schema-originals` — its premise (an external schema serves these) is gone; notation keeps `governance-lint.yml` and the scaffolder in-repo.

**Rewritten (survives):**
- `§road:relocate-conventions-content` — reframed to the notation/compose/conduct split per §spec:governance-schema ("Where today's CONVENTIONS.md content goes"): methodology → compose commands, process discipline → conduct commands + batch-agent. Folds in CONVENTIONS.md deletion (the one surviving piece of `remove-schema-originals`).

## Dangling-ref fixes (from #137, written pre-#123)
- `SPEC.md` §spec:scaffold-freshness — "migrates to the schema's scaffolder (§road:adopt-schema-scaffolder)" → "the `init` scaffolder becomes notation's."
- `ROADMAP.md` §road:scaffold-consumer-dependabot Verify — same repoint to notation.

No dangling references remain; every ROADMAP `§spec:` citation resolves; markdownlint clean.

## Not in this PR (flagged)
The decomposition itself (`§spec:governance-schema`, *not started*) now has only `relocate-conventions-content` rostered. Building notation/compose/conduct — plugin manifests, command relocation into plugin dirs, `{plugin}--v{version}` tagging, `dependencies` declarations — needs its own `/plan` + `/roadmap` pass. That's the recommended next step, not improvised here.