### PR TITLE
docs(roadmap): decompose plugin packaging and notation contract into workstreams

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,3 +59,166 @@ delegate-freshness contract in `commands/init.md`. §spec:scaffold-freshness
 governance-lint passes. The dependabot scaffolding lives with the `init`
 scaffolder — `commands/init.md` today, the notation plugin once the
 decomposition (§spec:governance-schema) builds it out.
+
+## Relocate the monolith
+
+The decomposition begins by relocating today's single root plugin into
+`plugins/symphonize/`, so the repo root holds only the marketplace manifest
+and the shared `.github/` workflows. This is a structural no-op for users —
+every command stays `/symphonize:*` — but it removes the `source: "./"`
+whole-repo-copy hazard before any sibling appears under `plugins/`: a
+root-sourced plugin in a repo that also nests `plugins/*` is an
+undocumented, untested case that would drag sibling trees into the
+umbrella's cache. notation, compose, and conduct are then carved out of
+`plugins/symphonize/`; what remains is the umbrella — the same plugin,
+relocated once and drained, never deleted or recreated. Depends on
+§road:relocate-conventions-content (command files self-contained before they
+move).
+
+### §road:relocate-monolith
+
+Move the repo's plugin into `plugins/symphonize/` — relocate `commands/`,
+`protocols/`, `hooks/`, and `.claude-plugin/plugin.json` (preserving its
+`name`, version, and history) under `plugins/symphonize/`, and point
+`.claude-plugin/marketplace.json` at `source: "./plugins/symphonize"`.
+§spec:plugin-packaging §spec:governance-schema
+
+**Verify:** every `/symphonize:*` command resolves exactly as before;
+installing the plugin copies only `plugins/symphonize/`'s tree into
+`~/.claude/plugins/cache/` (no repo-root siblings, no `.github/`);
+governance-lint passes.
+
+## Notation plugin
+
+The dependency root and the first separately-installable sibling — the
+walking skeleton. Carved out of `plugins/symphonize/`, it establishes the
+multi-plugin `marketplace.json` (a second entry) and the per-sibling
+`plugin.json` pattern the later carve-outs reuse. Depends on
+§road:relocate-monolith.
+
+### §road:extract-notation-plugin
+
+Create `plugins/notation/` with its `.claude-plugin/plugin.json`, move
+`commands/init.md` and `commands/lint.md` out of `plugins/symphonize/` into
+it under the `/notation:*` namespace, and add it to
+`.claude-plugin/marketplace.json` with `source: "./plugins/notation"`.
+§spec:plugin-packaging §spec:governance-schema
+
+### §road:rehome-notation-contract
+
+Confirm the root `.github/workflows/governance-lint.yml` enforces the full
+notation contract — status line and `§`-slug on every `##`/`###` heading,
+`§`-reference resolution, Vale-when-present, CHANGELOG excluded — and
+re-point notation's `lint` command and docs to notation as its owner.
+§spec:notation-contract
+
+**Verify:** `/plugin marketplace add repentsinner/symphonize` lists
+notation; installing notation alone exposes `/notation:init` and
+`/notation:lint` and no other commands; `/notation:init` scaffolds a repo;
+`/notation:lint` runs markdownlint; a SPEC heading missing a status line or
+a dangling `§`-reference fails governance-lint in CI.
+
+## compose plugin
+
+The tastemaking layer, carved out of `plugins/symphonize/`. Depends on
+§road:extract-notation-plugin (declares `dependencies: [notation]`) and
+§road:relocate-conventions-content (its authoring methodology is what moves
+inline here).
+
+### §road:extract-compose-plugin
+
+Create `plugins/compose/` with a `plugin.json` declaring
+`dependencies: [notation]`, move `discover`/`plan`/`roadmap`/`triage` and
+the correctness/taste half of `review` out of `plugins/symphonize/` into it
+under `/compose:*` — splitting `review` so the taste half lands here.
+§spec:plugin-packaging §spec:governance-schema
+
+**Verify:** installing compose auto-installs notation; `/compose:discover`,
+`/compose:plan`, `/compose:roadmap`, `/compose:triage`, and `/compose:review`
+appear and run; the former `/symphonize:plan` and siblings no longer
+resolve.
+
+## conduct plugin
+
+The execution layer, carved out of `plugins/symphonize/`. Depends on
+§road:extract-notation-plugin (declares `dependencies: [notation]`). After
+this carve-out `plugins/symphonize/` holds only `feedback`.
+
+### §road:extract-conduct-plugin
+
+Create `plugins/conduct/` with a `plugin.json` declaring
+`dependencies: [notation]`, and move `next`/`orchestrate`/`clean` and the
+integration/merge half of `review` plus `protocols/batch-agent.md` and the
+`hooks/` reconcile-repo-state hook out of `plugins/symphonize/` into it
+under `/conduct:*`. §spec:plugin-packaging §spec:governance-schema
+
+**Verify:** installing conduct auto-installs notation; `/conduct:next`,
+`/conduct:orchestrate`, `/conduct:clean`, and `/conduct:review` appear and
+run; the repo-state reconcile hook fires on a stale branch; the former
+`/symphonize:next` and siblings no longer resolve; `plugins/symphonize/`
+retains only `feedback`.
+
+## symphonize umbrella plugin
+
+With notation, compose, and conduct carved out, `plugins/symphonize/` holds
+only `feedback` (and later `yolo`). It becomes the umbrella by declaring its
+dependencies — no extraction, no new plugin. Depends on
+§road:extract-compose-plugin and §road:extract-conduct-plugin. `yolo`'s
+implementation is a separate, not-yet-roadmapped section (§spec:yolo-mode);
+this workstream only wires the dependencies `yolo` will need — the command
+lands later under its own roadmap pass.
+
+### §road:wire-symphonize-umbrella
+
+Add `dependencies: [compose, conduct]` to `plugins/symphonize/`'s
+`plugin.json` so installing `symphonize` pulls the whole product, and
+confirm the plugin now contains only `feedback`. §spec:plugin-packaging
+§spec:governance-schema
+
+**Verify:** installing `symphonize` auto-installs compose, conduct, and
+notation — the whole product in one install; `/symphonize:feedback` appears
+and runs; `plugins/symphonize/` contains only `feedback` (no carved-out
+commands remain); installing all four plugins yields the full former command
+set under the new namespaces.
+
+## Cross-plugin fragment assembly
+
+The residual content every plugin needs — the governance-root resolution
+algorithm and the `§`-slug grammar — cannot be shared by `../` reference
+across cached plugin directories. Until this section lands, the extraction
+sections above hand-copy that fragment into each plugin's commands. Depends
+on all four plugins existing (§road:wire-symphonize-umbrella).
+
+### §road:assemble-shared-fragment
+
+Add a canonical source fragment for the governance-root algorithm and
+`§`-grammar plus a build step that assembles it into each plugin's command
+files, and a CI check that fails when a committed command file drifts from a
+fresh assembly. §spec:plugin-packaging
+
+**Verify:** editing the canonical fragment and rebuilding updates every
+plugin's command files identically; hand-editing one assembled copy out of
+sync fails the CI drift-check; each plugin under `~/.claude/plugins/cache/`
+is self-contained with no `../` references.
+
+## Coordinated release
+
+One shared version line across the four plugins, tagged together. Depends
+on all four plugins existing (§road:wire-symphonize-umbrella).
+
+### §road:coordinate-plugin-release
+
+Reconfigure `release-please-config.json` and `.release-please-manifest.json`
+for the four `plugins/<name>/plugin.json` packages on one shared version,
+emit a `{plugin}--v{version}` git tag per plugin, pin compose's and
+conduct's notation `dependencies` range and symphonize's compose/conduct
+range to that version, and keep `update-major-tag.yml` moving notation's
+floating major for adopters' `governance-lint.yml@<major>` pin.
+§spec:plugin-packaging
+
+**Verify:** a release PR bumps all four `plugin.json` versions together;
+merging it publishes `notation--vX.Y.Z`, `compose--vX.Y.Z`,
+`conduct--vX.Y.Z`, and `symphonize--vX.Y.Z`; compose and conduct
+`dependencies` resolve notation, and symphonize resolves compose and
+conduct, at the shared version; a fresh scaffold's
+`governance-lint.yml@<major>` ref points at the released workflow.


### PR DESCRIPTION
Decomposes the plugin-restructure SPEC sections — `§spec:governance-schema`, `§spec:plugin-packaging`, `§spec:notation-contract` — into ROADMAP workstreams. `/roadmap` artifact (ROADMAP.md only). Rebased onto main; reflects the four-plugin layout merged in #143.

## Approach: relocate the monolith once, then carve it up

The repo's existing root plugin **is** `symphonize` — it owns the name, holds `feedback`, and carries the version lineage. So the decomposition doesn't create a new umbrella plugin; it relocates the monolith into `plugins/symphonize/` once, carves `notation`/`compose`/`conduct` out of it, and what remains is the umbrella.

Why relocate rather than leave it at `source: "./"`: namespace derives from the `plugin.json` `name` field, not the directory, so `plugins/symphonize/` still yields `/symphonize:*` with no loss. And `source: "./"` file-scoping is undocumented (no include/exclude globbing exists) — a root-sourced plugin in a repo that also nests `plugins/*` is an untested case that would drag sibling trees into the umbrella's cache. The documented monorepo pattern is uniformly `source: "./plugins/<name>"`.

## Seven sections, build-dependency order

1. **Relocate the monolith** (`relocate-monolith`) — move the root plugin into `plugins/symphonize/`; root becomes marketplace + shared CI only. Structural no-op for users (everything stays `/symphonize:*`).
2. **Notation plugin** (`extract-notation-plugin`, `rehome-notation-contract`) — dependency root and first separately-installable sibling (walking skeleton); carved out of `plugins/symphonize/`.
3. **compose plugin** (`extract-compose-plugin`) — `discover`/`plan`/`roadmap`/`triage` + taste half of `review`; `dependencies: [notation]`.
4. **conduct plugin** (`extract-conduct-plugin`) — `next`/`orchestrate`/`clean` + merge half of `review`, batch-agent protocol, reconcile hook; `dependencies: [notation]`. Leaves `plugins/symphonize/` holding only `feedback`.
5. **symphonize umbrella** (`wire-symphonize-umbrella`) — the remainder. Just adds `dependencies: [compose, conduct]`; no extraction, no new plugin. `yolo` lands later under `§spec:yolo-mode`.
6. **Cross-plugin fragment assembly** (`assemble-shared-fragment`) — canonical governance-root + `§`-grammar fragment, build step, CI drift-check.
7. **Coordinated release** (`coordinate-plugin-release`) — one shared version line across four plugins, `{plugin}--v{version}` tags, dependency pinning.

The existing `§road:relocate-conventions-content` is the precursor: it dissolves `CONVENTIONS.md` into the command files before they move.

## Notes for review

- **`review.md` splits across two plugins** — taste half → compose, merge half → conduct.
- **Orphan check.** All three restructure sections have workstreams. `§spec:yolo-mode` remains `not started` with no workstream by design — the `yolo` command build is a separate feature, roadmap it once the umbrella exists.

markdownlint clean; every cited `§spec:`/`§road:` slug resolves against the merged spec.