### PR TITLE
feat: batch — wire the symphonize umbrella plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "symphonize",
-      "description": "Depth-first roadmap execution engine",
+      "description": "Umbrella plugin: the whole-product entry point. Installs all layers (notation, compose, conduct) and houses feedback.",
       "source": "./plugins/symphonize"
     }
   ]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,36 +41,13 @@ the `init` scaffolder — `plugins/symphonize/commands/init.md` today, the
 notation plugin once the
 decomposition (§spec:governance-schema) builds it out.
 
-## symphonize umbrella plugin
-
-With notation, compose, and conduct carved out, `plugins/symphonize/` holds
-only `feedback` (and later `yolo`). It becomes the umbrella by declaring its
-dependencies — no extraction, no new plugin. compose and conduct are already
-extracted, so this workstream's dependencies are met. `yolo`'s
-implementation is a separate, not-yet-roadmapped section (§spec:yolo-mode);
-this workstream only wires the dependencies `yolo` will need — the command
-lands later under its own roadmap pass.
-
-### §road:wire-symphonize-umbrella
-
-Add `dependencies: [compose, conduct]` to `plugins/symphonize/`'s
-`plugin.json` so installing `symphonize` pulls the whole product, and
-confirm the plugin now contains only `feedback`. §spec:plugin-packaging
-§spec:governance-schema
-
-**Verify:** installing `symphonize` auto-installs compose, conduct, and
-notation — the whole product in one install; `/symphonize:feedback` appears
-and runs; `plugins/symphonize/` contains only `feedback` (no carved-out
-commands remain); installing all four plugins yields the full former command
-set under the new namespaces.
-
 ## Cross-plugin fragment assembly
 
 The residual content every plugin needs — the governance-root resolution
 algorithm and the `§`-slug grammar — cannot be shared by `../` reference
 across cached plugin directories. Until this section lands, the extraction
-sections above hand-copy that fragment into each plugin's commands. Depends
-on all four plugins existing (§road:wire-symphonize-umbrella).
+sections above hand-copy that fragment into each plugin's commands. All four
+plugins now exist.
 
 ### §road:assemble-shared-fragment
 
@@ -86,8 +63,8 @@ is self-contained with no `../` references.
 
 ## Coordinated release
 
-One shared version line across the four plugins, tagged together. Depends
-on all four plugins existing (§road:wire-symphonize-umbrella).
+One shared version line across the four plugins, tagged together. All four
+plugins now exist.
 
 ### §road:coordinate-plugin-release
 

--- a/plugins/symphonize/.claude-plugin/plugin.json
+++ b/plugins/symphonize/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "symphonize",
   "version": "0.1.39",
-  "description": "Depth-first roadmap execution engine. Turns ROADMAP.md workstreams into batched PRs via worktree-isolated agents.",
+  "description": "Umbrella plugin for symphonize: the whole-product entry point. Depends on compose and conduct (and transitively notation) to install all layers, and houses the feedback command.",
   "author": {
     "name": "repentsinner"
   },
@@ -12,5 +12,9 @@
     "roadmap",
     "batch",
     "worktree"
+  ],
+  "dependencies": [
+    { "name": "compose", "version": "0.1.39" },
+    { "name": "conduct", "version": "0.1.39" }
   ]
 }


### PR DESCRIPTION
Implements `§road:wire-symphonize-umbrella` — the final structural step of the four-plugin decomposition. The symphonize plugin becomes the umbrella by declaring its dependencies; no files move.

## Change
- `plugins/symphonize/.claude-plugin/plugin.json`:
  ```json
  "dependencies": [
    { "name": "compose", "version": "0.1.39" },
    { "name": "conduct", "version": "0.1.39" }
  ]
  ```
  (notation arrives transitively via compose and conduct — not listed directly.)
- Rewrote the symphonize `description` (in plugin.json and the marketplace entry) from "Depth-first roadmap execution engine" (now conduct's role) to the umbrella role: whole-product entry point that installs all layers and houses `feedback`.

## Resulting dependency graph
```
notation (root)  ←  compose  ┐
       ↑                      ├─ symphonize  (feedback; later yolo)
       └────────  conduct  ───┘
```
Installing `symphonize` pulls compose + conduct + (transitively) notation — the whole product in one install.

## State
- `plugins/symphonize/` holds only `commands/feedback.md` + its manifest.
- All four manifests are valid, on the shared 0.1.39 version line.
- The four-plugin scaffolding is now **structurally complete.** Remaining: `§road:assemble-shared-fragment` (cross-plugin fragment + CI drift-check) and `§road:coordinate-plugin-release` (release-please for four packages) — both still in ROADMAP.

## Governance
- ROADMAP: "symphonize umbrella plugin" section removed.
- SPEC: `§spec:plugin-packaging` / `§spec:governance-schema` remain `in progress` — assembly + coordinated release are not done, so neither is complete.

## Gates
- **Security review:** clean — declarative manifest/description + governance prose only.
- **/simplify:** skipped (no source files).
- **markdownlint:** clean; CI will confirm governance-lint.

> Run /review --comment to post code-quality findings as PR comments.