### PR TITLE
feat: batch — cross-plugin fragment assembly with drift-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,17 @@ jobs:
     uses: ./.github/workflows/governance-lint.yml
     with:
       readme-type: library
+
+  fragment-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Re-assemble canonical fragments into their consumers, then fail if a
+      # committed command file drifted from a fresh assembly. Local fix:
+      # run `tools/assemble-fragments.sh` and commit. See fragments/README.md
+      # and SPEC §spec:plugin-packaging.
+      - name: Assemble fragments and check for drift
+        run: |
+          bash tools/assemble-fragments.sh
+          git diff --exit-code

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,26 +41,6 @@ the `init` scaffolder — `plugins/symphonize/commands/init.md` today, the
 notation plugin once the
 decomposition (§spec:governance-schema) builds it out.
 
-## Cross-plugin fragment assembly
-
-The residual content every plugin needs — the governance-root resolution
-algorithm and the `§`-slug grammar — cannot be shared by `../` reference
-across cached plugin directories. Until this section lands, the extraction
-sections above hand-copy that fragment into each plugin's commands. All four
-plugins now exist.
-
-### §road:assemble-shared-fragment
-
-Add a canonical source fragment for the governance-root algorithm and
-`§`-grammar plus a build step that assembles it into each plugin's command
-files, and a CI check that fails when a committed command file drifts from a
-fresh assembly. §spec:plugin-packaging
-
-**Verify:** editing the canonical fragment and rebuilding updates every
-plugin's command files identically; hand-editing one assembled copy out of
-sync fails the CI drift-check; each plugin under `~/.claude/plugins/cache/`
-is self-contained with no `../` references.
-
 ## Coordinated release
 
 One shared version line across the four plugins, tagged together. All four

--- a/SPEC.md
+++ b/SPEC.md
@@ -865,12 +865,17 @@ read files outside their own directory — `../` into a sibling plugin fails.
 Most of today's shared `CONVENTIONS.md` content becomes single-owner under
 the decomposition: authoring methodology in compose's commands, process
 discipline in conduct's commands and `protocols/batch-agent.md`, the
-structural grammar in notation's linter. The residual every plugin needs —
-the governance-root resolution algorithm and the `§`-slug grammar — lives
-once as a canonical source fragment and is **assembled** into each plugin's
-command files by a build step. CI fails when a committed command file
-drifts from a fresh assembly, so each cached plugin stays self-contained
-while the fragment keeps one source of truth.
+structural grammar in notation's linter. The residual that several commands
+duplicate verbatim — the governance-root resolution algorithm — lives once
+under `fragments/` and is **assembled** into each consuming command file
+by `tools/assemble-fragments.sh`, between `<!-- assembled:<name> -->`
+markers. Each consumer's own surrounding context (its heading, the files it
+reads and writes, its upstream-context paragraph) stays hand-authored
+outside the markers. CI re-runs the build then `git diff --exit-code`, so a
+committed command file that drifts from a fresh assembly fails the job. Each
+cached plugin stays self-contained while the fragment keeps one source of
+truth. (The `§`-slug grammar is not duplicated as one identical block — it
+appears as command-specific format guidance — so it is not a fragment.)
 
 **Why a build step, not symlinks:** a symlink into a sibling plugin
 resolves at install-time copy and dangles in the cache. Assembly resolves

--- a/fragments/README.md
+++ b/fragments/README.md
@@ -1,0 +1,45 @@
+# Canonical fragments
+
+Single-source content assembled into multiple plugin command files.
+
+## Why
+
+Installed plugins are copied into `~/.claude/plugins/cache/` and cannot read
+files outside their own directory — `../` into a sibling plugin dangles at
+cache-copy time (SPEC §spec:plugin-packaging). Shared content must therefore
+physically live inside each plugin. Hand-duplication drifts. Each fragment
+here is the one source of truth; `tools/assemble-fragments.sh` writes it into
+every consumer, and CI fails when a committed copy drifts.
+
+## Fragments
+
+- **governance-root.md** — the governance-root resolution algorithm (walk up
+  from CWD to the nearest ancestor containing SPEC.md; fall back to the repo
+  root). Consumed by `compose` (`discover`, `plan`, `roadmap`) and `conduct`
+  (`next`).
+
+## Markers
+
+Each consumer delimits the assembled region with HTML comments:
+
+```markdown
+<!-- assembled:governance-root -->
+... canonical content, overwritten by the build ...
+<!-- /assembled:governance-root -->
+```
+
+Everything outside the markers is hand-authored and untouched by the build —
+including each command's own surrounding context (the section heading, the
+intro sentence, the per-command list of files read and written, and the
+upstream-context paragraph), which legitimately varies per command.
+
+## Build
+
+```sh
+tools/assemble-fragments.sh
+```
+
+Idempotent. The consumer registry lives in the script's `CONSUMERS` array;
+add a `fragment|path` entry to enroll a new file. CI runs the build then
+`git diff --exit-code`, so a drifted committed file fails the job. The fix is
+the same command: run `tools/assemble-fragments.sh` and commit.

--- a/fragments/governance-root.md
+++ b/fragments/governance-root.md
@@ -1,0 +1,3 @@
+1. Walk up from the current working directory to find the nearest
+   ancestor directory containing SPEC.md.
+2. If no ancestor contains SPEC.md, fall back to the repository root.

--- a/plugins/compose/commands/discover.md
+++ b/plugins/compose/commands/discover.md
@@ -6,9 +6,11 @@ description: Interview the user to produce or update REQUIREMENTS.md
 
 Resolve the governance root before reading or writing governance files:
 
+<!-- assembled:governance-root -->
 1. Walk up from the current working directory to find the nearest
    ancestor directory containing SPEC.md.
 2. If no ancestor contains SPEC.md, fall back to the repository root.
+<!-- /assembled:governance-root -->
 3. All governance file reads and writes in subsequent steps are
    relative to the governance root, not the repository root.
 

--- a/plugins/compose/commands/plan.md
+++ b/plugins/compose/commands/plan.md
@@ -6,9 +6,11 @@ description: Technical decisions — explore design options and produce SPEC.md 
 
 Resolve the governance root before reading or writing governance files:
 
+<!-- assembled:governance-root -->
 1. Walk up from the current working directory to find the nearest
    ancestor directory containing SPEC.md.
 2. If no ancestor contains SPEC.md, fall back to the repository root.
+<!-- /assembled:governance-root -->
 3. All governance file reads and writes in subsequent steps are
    relative to the governance root, not the repository root.
 

--- a/plugins/compose/commands/roadmap.md
+++ b/plugins/compose/commands/roadmap.md
@@ -6,9 +6,11 @@ description: Break spec sections into ROADMAP.md workstreams
 
 Resolve the governance root before reading or writing governance files:
 
+<!-- assembled:governance-root -->
 1. Walk up from the current working directory to find the nearest
    ancestor directory containing SPEC.md.
 2. If no ancestor contains SPEC.md, fall back to the repository root.
+<!-- /assembled:governance-root -->
 3. All governance file reads and writes in subsequent steps are
    relative to the governance root, not the repository root.
 

--- a/plugins/conduct/commands/next.md
+++ b/plugins/conduct/commands/next.md
@@ -10,9 +10,11 @@ pre-flight steps below.
 
 Resolve the governance root before selecting work:
 
+<!-- assembled:governance-root -->
 1. Walk up from the current working directory to find the nearest
    ancestor directory containing SPEC.md.
 2. If no ancestor contains SPEC.md, fall back to the repository root.
+<!-- /assembled:governance-root -->
 3. All governance file reads (ROADMAP.md, SPEC.md, REQUIREMENTS.md)
    and writes (progress file) in subsequent steps are relative to
    the governance root, not the repository root.

--- a/tools/assemble-fragments.sh
+++ b/tools/assemble-fragments.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Assemble canonical fragments into consuming command files.
+#
+# Cross-plugin fragment assembly (SPEC §spec:plugin-packaging): installed
+# plugins are copied into ~/.claude/plugins/cache/ and cannot read files
+# outside their own directory, so shared content must physically live inside
+# each plugin. Hand-duplication drifts; this script keeps one canonical
+# source and writes it into every consumer between marker comments.
+#
+# Idempotent: running it when everything is in sync produces no changes.
+# CI runs it then `git diff --exit-code` to fail on drift (see
+# .github/workflows/ci.yml). Local fix on drift: run this script and commit.
+#
+# Usage: tools/assemble-fragments.sh
+set -euo pipefail
+
+# Resolve repo root from this script's location so the tool works regardless
+# of the caller's working directory.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+FRAGMENTS_DIR="${REPO_ROOT}/fragments"
+
+# Consumer registry: "fragment_name|relative/path/to/command.md".
+# Each consumer wraps the assembled region in:
+#   <!-- assembled:<fragment_name> --> ... <!-- /assembled:<fragment_name> -->
+# Everything outside the markers is hand-authored and untouched.
+CONSUMERS=(
+  "governance-root|plugins/compose/commands/discover.md"
+  "governance-root|plugins/compose/commands/plan.md"
+  "governance-root|plugins/compose/commands/roadmap.md"
+  "governance-root|plugins/conduct/commands/next.md"
+)
+
+# assemble FRAGMENT_NAME TARGET_FILE
+# Replaces the content between the fragment's markers in TARGET_FILE with the
+# canonical fragment. Fails loudly if a marker is missing or unbalanced.
+assemble() {
+  local fragment_name="$1"
+  local target_rel="$2"
+  local target="${REPO_ROOT}/${target_rel}"
+  local fragment_file="${FRAGMENTS_DIR}/${fragment_name}.md"
+  local open_marker="<!-- assembled:${fragment_name} -->"
+  local close_marker="<!-- /assembled:${fragment_name} -->"
+
+  if [ ! -f "$fragment_file" ]; then
+    echo "error: missing canonical fragment: ${fragment_file}" >&2
+    exit 1
+  fi
+  if [ ! -f "$target" ]; then
+    echo "error: missing consumer file: ${target}" >&2
+    exit 1
+  fi
+
+  local open_count close_count
+  open_count="$(grep -cF "$open_marker" "$target" || true)"
+  close_count="$(grep -cF "$close_marker" "$target" || true)"
+  if [ "$open_count" != "1" ] || [ "$close_count" != "1" ]; then
+    echo "error: ${target_rel} must contain exactly one '${open_marker}'" \
+         "and one '${close_marker}' (found ${open_count} open," \
+         "${close_count} close)" >&2
+    exit 1
+  fi
+
+  # Rewrite the file: keep everything up to and including the open marker,
+  # emit the canonical fragment, then resume from the close marker onward.
+  # awk handles arbitrary marker content without shell-escaping the body.
+  local tmp
+  tmp="$(mktemp)"
+  awk -v openm="$open_marker" -v closem="$close_marker" \
+      -v frag="$fragment_file" '
+    $0 == openm {
+      print
+      while ((getline line < frag) > 0) print line
+      close(frag)
+      skip = 1
+      next
+    }
+    $0 == closem { skip = 0 }
+    !skip { print }
+  ' "$target" > "$tmp"
+
+  mv "$tmp" "$target"
+  echo "assembled ${fragment_name} -> ${target_rel}"
+}
+
+for entry in "${CONSUMERS[@]}"; do
+  fragment_name="${entry%%|*}"
+  target_rel="${entry#*|}"
+  assemble "$fragment_name" "$target_rel"
+done
+
+echo "done"


### PR DESCRIPTION
Implements `§road:assemble-shared-fragment` — a canonical source fragment assembled into consuming command files by a build step, with a CI drift-check. Solves the cache-isolation problem (§spec:plugin-packaging): installed plugins are copied to `~/.claude/plugins/cache/` and cannot `../` into siblings, so shared content must physically live in each plugin — but hand-duplication drifts.

## Mechanism
- **Canonical source:** `fragments/governance-root.md` (the numbered walk-up algorithm) + `fragments/README.md` documenting the convention.
- **Markers:** consumers delimit the assembled region with `<!-- assembled:governance-root -->` … `<!-- /assembled:governance-root -->`; everything outside is hand-authored.
- **Build:** `tools/assemble-fragments.sh` (POSIX/awk, `set -euo pipefail`, `mktemp`) writes each canonical fragment between the markers in every registered consumer. Idempotent. Consumer registry is the `CONSUMERS` array.
- **CI drift-check:** new `fragment-drift` job in `ci.yml` runs the build then `git diff --exit-code` — a committed file that drifted from canonical fails the job. Fix = run the script and commit.

## ⚠️ Scope narrowing — please ratify
The agent found the spec's original fragment scope didn't match reality, and **amended `§spec:plugin-packaging`** accordingly. Two narrowings:

1. **Only the governance-root walk-up is a fragment** — the `§`-slug grammar named in the original spec is **not** a verbatim-shared block (it appears as command-specific format guidance), so it's not assembled. The spec was edited to say so.
2. **Only 4 consumers** — compose (`discover`, `plan`, `roadmap`) and conduct (`next`) carry the *verbatim numbered* walk-up block. The other governance-root mentions are intentionally **excluded** because they differ:
   - `notation/init` uses a *different* algorithm (CWD-based, not walk-up).
   - `notation/lint`, `conduct/clean`, `conduct/orchestrate` phrase it as command-specific prose, not the numbered block.

**Consequence:** those prose-form descriptions still restate the algorithm and can drift from canonical without CI catching it. The agent's call (don't force prose commands into an identical block) is defensible, but it means the "no drift, each plugin self-contained" promise holds only for the 4 verbatim consumers. If you want broader coverage (normalize the prose forms to consume the fragment too), that's a follow-up.

## Verification (I ran these against the branch)
- Build is idempotent (no diff on a clean tree).
- Committed drift is caught: hand-edit a consumer's assembled region + commit → build restores canonical → `git diff --exit-code` ≠ 0 → CI fails. ✅
- No `../` crossing plugin boundaries in assembled content. ✅

## Governance
- ROADMAP: "Cross-plugin fragment assembly" section removed.
- SPEC: `§spec:plugin-packaging` text amended (fragment scope); stays `in progress` (coordinated release pending).

## Gates
- **Security review:** clean — script takes no external input, exact-string awk matching (no eval), `mktemp`, fails closed.
- **/simplify:** ran (build script in scope).
- **CI:** the new drift-check is green (build was run before commit).

> Run /review --comment to post code-quality findings as PR comments.