### PR TITLE
ci: set least-privilege permissions on the fragment-drift job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
 
   fragment-drift:
     runs-on: ubuntu-latest
+    # Least-privilege: this job only reads the checked-out tree (re-assemble
+    # fragments, diff for drift). No write to contents/checks/PRs needed.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Addresses the CodeQL finding on #150 ([code-scanning alert 4](https://github.com/repentsinner/symphonize/security/code-scanning/4)): *"Workflow does not contain permissions — Actions job or workflow does not limit the permissions of the GITHUB_TOKEN."*

## Fix
Adds a job-level `permissions: { contents: read }` to the `fragment-drift` job (introduced in #150). That job only checks out the tree, re-assembles fragments, and diffs — it needs no write scope.

## Why job-level, not workflow-level
A workflow-level `permissions: contents: read` would also constrain the `governance-lint` reusable-workflow call, whose `vale-action` step (active here — `.vale.ini` exists) posts annotations via reviewdog and relies on the repo's default token write scope. Constraining it risks breaking prose-lint annotation posting. Scoping the least-privilege block to the flagged `fragment-drift` job resolves the alert without touching the linter's working token.

If `governance-lint`'s own least-privilege hardening is wanted, it belongs in the reusable workflow (`governance-lint.yml`) with vale's exact needs declared — a separate change.

> Run /review --comment to post code-quality findings as PR comments.