### PR TITLE
docs(roadmap): add fragment-assembly coverage normalization workstream

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,3 +62,35 @@ merging it publishes `notation--vX.Y.Z`, `compose--vX.Y.Z`,
 `dependencies` resolve notation, and symphonize resolves compose and
 conduct, at the shared version; a fresh scaffold's
 `governance-lint.yml@<major>` ref points at the released workflow.
+
+## Fragment assembly coverage
+
+The fragment-assembly mechanism (`tools/assemble-fragments.sh` plus the CI
+drift-check, §spec:plugin-packaging) single-sources the governance-root
+algorithm, but only for the four command files that carried it as a verbatim
+numbered block. Three other command files restate the same
+algorithm as command-specific prose and stay hand-maintained — free to drift
+from the canonical fragment without the CI drift-check noticing. This section
+closes that gap, completing the no-drift intent. It reverses the coverage
+narrowing §spec:plugin-packaging recorded when the mechanism landed, so the work
+includes reconciling that spec text to describe full coverage.
+
+### §road:normalize-governance-root-restatements
+
+Bring the prose-form governance-root restatements under the canonical
+fragment — register `plugins/notation/commands/lint.md` and
+`plugins/conduct/commands/clean.md` as `governance-root` consumers (marked,
+assembled block), trim `plugins/conduct/commands/orchestrate.md` to defer
+resolution to `/conduct:next` rather than restating the walk-up, leave
+`plugins/notation/commands/init.md`'s deliberately different CWD-based
+algorithm untouched — and reconcile §spec:plugin-packaging's coverage
+description. §spec:plugin-packaging
+
+**Verify:** `tools/assemble-fragments.sh`'s consumer registry includes
+lint.md and clean.md and the CI fragment-drift job covers them; editing
+`fragments/governance-root.md` then rebuilding updates lint.md and clean.md
+identically; `orchestrate.md` references `/conduct:next` for governance-root
+resolution instead of restating the algorithm; a grep across
+`plugins/*/commands/` finds no unmanaged verbatim restatement of the walk-up
+algorithm (init.md's distinct CWD-based text excepted); governance-lint and
+the fragment-drift job pass.


### PR DESCRIPTION
Adds a follow-up workstream (`§road:normalize-governance-root-restatements`) to finish what #150 started: bring the remaining governance-root restatements under the canonical fragment so the CI drift-check covers them.

## Why
`§road:assemble-shared-fragment` (merged in #150) single-sourced the governance-root algorithm, but only for the **4 files** carrying it as a verbatim numbered block (compose: discover/plan/roadmap; conduct: next). **3 files restate the same algorithm as command-specific prose** and stay hand-maintained, free to drift un-caught:
- `notation/lint.md`, `conduct/clean.md` — same walk-up rule, prose form.
- `conduct/orchestrate.md` — restates it, but actually *defers* resolution to `/conduct:next`.

(`notation/init.md` uses a genuinely different CWD-based algorithm — correctly excluded.)

## The workstream
- Register `lint.md` and `clean.md` as `governance-root` consumers (marked, assembled block).
- Trim `orchestrate.md` to defer to `/conduct:next` rather than restate the algorithm (no drift-able copy).
- Leave `init.md` untouched.
- **Reconcile `§spec:plugin-packaging`** — #150 amended that section to record the *narrowed* coverage; this work reverses that, so the spec text needs updating to describe full coverage.

## Note on traceability
This workstream intentionally **reverses a design narrowing** the #150 batch recorded in `§spec:plugin-packaging`. Strictly, that spec revision is `/plan`'s job — I've folded "reconcile the spec text" into the workstream deliverable (the implementing `/next` batch updates it, as the #150 batch did). If you'd rather the spec be revised up front via `/plan` for cleaner traceability before this is executed, say so and I'll route it that way.

Adds one section at the tail; markdownlint clean; `§spec:plugin-packaging` resolves.