### PR TITLE
feat: batch — normalize governance-root restatements under the fragment

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,35 +62,3 @@ merging it publishes `notation--vX.Y.Z`, `compose--vX.Y.Z`,
 `dependencies` resolve notation, and symphonize resolves compose and
 conduct, at the shared version; a fresh scaffold's
 `governance-lint.yml@<major>` ref points at the released workflow.
-
-## Fragment assembly coverage
-
-The fragment-assembly mechanism (`tools/assemble-fragments.sh` plus the CI
-drift-check, §spec:plugin-packaging) single-sources the governance-root
-algorithm, but only for the four command files that carried it as a verbatim
-numbered block. Three other command files restate the same
-algorithm as command-specific prose and stay hand-maintained — free to drift
-from the canonical fragment without the CI drift-check noticing. This section
-closes that gap, completing the no-drift intent. It reverses the coverage
-narrowing §spec:plugin-packaging recorded when the mechanism landed, so the work
-includes reconciling that spec text to describe full coverage.
-
-### §road:normalize-governance-root-restatements
-
-Bring the prose-form governance-root restatements under the canonical
-fragment — register `plugins/notation/commands/lint.md` and
-`plugins/conduct/commands/clean.md` as `governance-root` consumers (marked,
-assembled block), trim `plugins/conduct/commands/orchestrate.md` to defer
-resolution to `/conduct:next` rather than restating the walk-up, leave
-`plugins/notation/commands/init.md`'s deliberately different CWD-based
-algorithm untouched — and reconcile §spec:plugin-packaging's coverage
-description. §spec:plugin-packaging
-
-**Verify:** `tools/assemble-fragments.sh`'s consumer registry includes
-lint.md and clean.md and the CI fragment-drift job covers them; editing
-`fragments/governance-root.md` then rebuilding updates lint.md and clean.md
-identically; `orchestrate.md` references `/conduct:next` for governance-root
-resolution instead of restating the algorithm; a grep across
-`plugins/*/commands/` finds no unmanaged verbatim restatement of the walk-up
-algorithm (init.md's distinct CWD-based text excepted); governance-lint and
-the fragment-drift job pass.

--- a/plugins/conduct/commands/clean.md
+++ b/plugins/conduct/commands/clean.md
@@ -3,9 +3,13 @@ argument-hint: [--lite | --full]
 description: Cleans up after executing batch workstreams
 ---
 
-Resolve the governance root before operating: walk up from the current
-working directory to the nearest ancestor containing SPEC.md; if none
-is found, fall back to the repository root.
+Resolve the governance root before operating:
+
+<!-- assembled:governance-root -->
+1. Walk up from the current working directory to find the nearest
+   ancestor directory containing SPEC.md.
+2. If no ancestor contains SPEC.md, fall back to the repository root.
+<!-- /assembled:governance-root -->
 
 Two modes: `--lite` and `--full`. If no flag is passed, auto-detect:
 use `--lite` if `.claude/ralph-loop.local.md` exists, `--full`

--- a/plugins/conduct/commands/orchestrate.md
+++ b/plugins/conduct/commands/orchestrate.md
@@ -2,9 +2,8 @@
 description: Start ralph-loop to work through ROADMAP.md
 ---
 The governance root is determined by the current working directory
-when this command is invoked. `/conduct:next` resolves the
-governance root (walk up from CWD to the nearest ancestor containing
-SPEC.md; fall back to the repository root).
+when this command is invoked. `/conduct:next` resolves the governance
+root.
 
 Run `/conduct:clean --lite` to ensure local state is clean before
 starting the loop.

--- a/plugins/notation/commands/lint.md
+++ b/plugins/notation/commands/lint.md
@@ -7,9 +7,13 @@ markdownlint against all matches. Uses the project's
 `.markdownlint.json` if present (markdownlint resolves config by
 walking up the directory tree natively).
 
-Resolve the governance root by walking up from the current working
-directory to the nearest ancestor containing SPEC.md; fall back to the
-repository root.
+Resolve the governance root before globbing for governance files:
+
+<!-- assembled:governance-root -->
+1. Walk up from the current working directory to find the nearest
+   ancestor directory containing SPEC.md.
+2. If no ancestor contains SPEC.md, fall back to the repository root.
+<!-- /assembled:governance-root -->
 
 ## Procedure
 

--- a/tools/assemble-fragments.sh
+++ b/tools/assemble-fragments.sh
@@ -29,6 +29,8 @@ CONSUMERS=(
   "governance-root|plugins/compose/commands/plan.md"
   "governance-root|plugins/compose/commands/roadmap.md"
   "governance-root|plugins/conduct/commands/next.md"
+  "governance-root|plugins/notation/commands/lint.md"
+  "governance-root|plugins/conduct/commands/clean.md"
 )
 
 # assemble FRAGMENT_NAME TARGET_FILE


### PR DESCRIPTION
Implements `§road:normalize-governance-root-restatements` — finishes what #150 started by bringing the remaining governance-root restatements under the canonical fragment, so the CI `fragment-drift` job now protects all genuine duplicates of the walk-up algorithm.

## Per-file
- **`notation/lint.md`** and **`conduct/clean.md`** — prose restatement → fragment consumer. Each keeps its command-specific framing sentence (hand-authored, outside the markers) with the canonical numbered walk-up block between `<!-- assembled:governance-root -->` markers. Both registered in `tools/assemble-fragments.sh`'s `CONSUMERS`.
- **`conduct/orchestrate.md`** — already *defers* governance-root resolution to `/conduct:next`; trimmed so it no longer restates the walk-up steps (no drift-able copy).
- **`notation/init.md`** — left untouched. Its governance-root rule is genuinely different (CWD-based, no walk-up) by design.

## CONSUMERS (now 6)
`compose: discover, plan, roadmap` · `conduct: next` · **`notation: lint`** · **`conduct: clean`**

## Spec
No prose change needed — `§spec:plugin-packaging` already says the algorithm is "assembled into each consuming command file," which now truthfully includes lint/clean. The "`§`-grammar is not a fragment" parenthetical stays valid.

## Verification (I ran these against the branch)
- Build idempotent (no diff on clean tree). ✅
- Drift caught: corrupt lint's assembled region + commit → rebuild → `git diff --exit-code` ≠ 0 → CI fails. ✅
- `init.md` still CWD-based and unmarked. ✅
- No unmanaged restatement of the walk-up algorithm remains in `plugins/*/commands/`. ✅

## Governance
- ROADMAP: "Fragment assembly coverage" section removed.
- SPEC: `§spec:plugin-packaging` / `§spec:governance-schema` stay `in progress` (coordinated release pending).

## Gates
- **Security review:** clean — markdown + two static registry literals in the shell script.
- **/simplify:** registry edit only; no logic change.

> Run /review --comment to post code-quality findings as PR comments.