### PR TITLE
feat: batch — coordinated four-plugin release

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -9,12 +9,22 @@ permissions:
 
 jobs:
   update-major-tag:
+    # Only the notation release moves a floating major tag. Adopters pin the
+    # reusable governance-lint.yml workflow cross-repo via
+    # `@notation--v<major>` (§spec:plugin-packaging, §spec:notation-contract);
+    # compose/conduct/symphonize reach adopters through marketplace plugin
+    # installs (dependency ranges), not a git ref, so floating majors for them
+    # would be unused. The coordinated version line guarantees notation--v<major>
+    # names the same release as the other three plugins' tags.
+    if: startsWith(github.ref_name, 'notation--v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
       - name: Move floating major tag
         run: |
+          # GITHUB_REF_NAME is the released tag, e.g. notation--v0.2.0.
+          # Strip at the first '.' to get the floating major, e.g. notation--v0.
           version="${GITHUB_REF_NAME}"
           major="${version%%.*}"
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,6 @@
 {
-  ".": "0.1.39"
+  "plugins/notation": "0.1.39",
+  "plugins/compose": "0.1.39",
+  "plugins/conduct": "0.1.39",
+  "plugins/symphonize": "0.1.39"
 }

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ on:
 
 jobs:
   lint:
-    uses: repentsinner/symphonize/.github/workflows/governance-lint.yml@v1
+    uses: repentsinner/symphonize/.github/workflows/governance-lint.yml@notation--v0
     with:
       readme-type: library  # or "application", or "" to skip
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,25 +40,3 @@ the contract; governance-lint passes. The dependabot scaffolding lives with
 the `init` scaffolder — `plugins/symphonize/commands/init.md` today, the
 notation plugin once the
 decomposition (§spec:governance-schema) builds it out.
-
-## Coordinated release
-
-One shared version line across the four plugins, tagged together. All four
-plugins now exist.
-
-### §road:coordinate-plugin-release
-
-Reconfigure `release-please-config.json` and `.release-please-manifest.json`
-for the four `plugins/<name>/plugin.json` packages on one shared version,
-emit a `{plugin}--v{version}` git tag per plugin, pin compose's and
-conduct's notation `dependencies` range and symphonize's compose/conduct
-range to that version, and keep `update-major-tag.yml` moving notation's
-floating major for adopters' `governance-lint.yml@<major>` pin.
-§spec:plugin-packaging
-
-**Verify:** a release PR bumps all four `plugin.json` versions together;
-merging it publishes `notation--vX.Y.Z`, `compose--vX.Y.Z`,
-`conduct--vX.Y.Z`, and `symphonize--vX.Y.Z`; compose and conduct
-`dependencies` resolve notation, and symphonize resolves compose and
-conduct, at the shared version; a fresh scaffold's
-`governance-lint.yml@<major>` ref points at the released workflow.

--- a/SPEC.md
+++ b/SPEC.md
@@ -52,7 +52,7 @@ The command creates:
 - `CHANGELOG.md` — with `## [Unreleased]` section
 - `.markdownlint.json` — default config
 - `.github/workflows/governance-lint.yml` — caller workflow
-  referencing `repentsinner/symphonize/.github/workflows/governance-lint.yml@v1`
+  referencing `repentsinner/symphonize/.github/workflows/governance-lint.yml@notation--v0`
 - `.github/workflows/release-please.yml` — release-please action
   with config and manifest files
 - `.github/workflows/auto-merge-release.yml` — auto-merge for
@@ -101,8 +101,10 @@ github-actions[bot] with the `autorelease: pending` label.
 
 ### update-major-tag.yml
 
-Template workflow that moves a floating major version tag
-(e.g., `v1`) on each release.
+Template workflow that moves a floating major version tag on each
+release. In symphonize it is gated to the notation release, moving
+`notation--v<major>` (e.g. `notation--v0`) — the adopter-facing ref
+for the reusable `governance-lint.yml`.
 
 ## Scaffolding freshness §spec:scaffold-freshness
 *Status: in progress*
@@ -115,7 +117,8 @@ later evolution. Two freshness concerns follow from that boundary, with
 different owners.
 
 Symphonize ships its workflow templates two ways (§spec:reusable-ci):
-`governance-lint.yml` is scaffolded as a `@v1` reusable caller, so a
+`governance-lint.yml` is scaffolded as a `@notation--v0` reusable caller
+(the notation-scoped floating major; pre-1.0, so `v0`, not `v1`), so a
 consumer picks up symphonize's internal action bumps transitively; the
 release, auto-merge, and major-tag workflows are copied verbatim because
 each needs project-specific manifests and tokens, so a consumer holds a
@@ -800,9 +803,9 @@ home is still pending:
   linter later would mean re-extracting it. Accepted given the
   symphonize-specific decision.
 - Adopter projects reference the reusable `governance-lint.yml` cross-repo
-  via a notation-scoped major tag rather than a dedicated repository's
-  `@v1`. The tag name carries the version; the cosmetic difference is
-  accepted.
+  via a notation-scoped major tag (`@notation--v0`) rather than a dedicated
+  repository's `@v1`. The tag name carries the version; the cosmetic
+  difference is accepted.
 
 ## Plugin packaging and distribution §spec:plugin-packaging
 *Status: in progress*

--- a/plugins/notation/commands/init.md
+++ b/plugins/notation/commands/init.md
@@ -130,12 +130,17 @@ Create under `.github/workflows/`:
 
   jobs:
     lint:
-      uses: repentsinner/symphonize/.github/workflows/governance-lint.yml@v1
+      uses: repentsinner/symphonize/.github/workflows/governance-lint.yml@notation--v0
       with:
         readme-type: ""
   ```
   Ask the user whether their project is a `library` or `application`
   and set `readme-type` accordingly. Leave empty if they decline.
+
+  Pin the `@notation--v0` floating major tag: `governance-lint.yml`
+  belongs to the notation plugin, whose coordinated version line is
+  pre-1.0, so the adopter-facing major ref is `notation--v0` (not `v1`).
+  `update-major-tag.yml` moves this tag forward on each notation release.
 
 - **release-please.yml** — copy from symphonize's template. Also
   create `release-please-config.json` and

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,15 +1,84 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": true,
+  "tag-separator": "--",
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "symphonize-plugins",
+      "components": ["notation", "compose", "conduct", "symphonize"]
+    }
+  ],
   "packages": {
-    ".": {
+    "plugins/notation": {
       "release-type": "simple",
+      "component": "notation",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
         {
           "type": "json",
-          "path": "plugins/symphonize/.claude-plugin/plugin.json",
+          "path": ".claude-plugin/plugin.json",
           "jsonpath": "$.version"
+        }
+      ]
+    },
+    "plugins/compose": {
+      "release-type": "simple",
+      "component": "compose",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.dependencies[0].version"
+        }
+      ]
+    },
+    "plugins/conduct": {
+      "release-type": "simple",
+      "component": "conduct",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.dependencies[0].version"
+        }
+      ]
+    },
+    "plugins/symphonize": {
+      "release-type": "simple",
+      "component": "symphonize",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.dependencies[0].version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.dependencies[1].version"
         }
       ]
     }


### PR DESCRIPTION
Implements `§road:coordinate-plugin-release` — reconfigures release-please so the four plugins share one version line, release together, and tag as `{plugin}--v{version}`. **The last code piece of the plugin decomposition.**

## release-please config
- **`linked-versions` plugin** (`components: [notation, compose, conduct, symphonize]`) — bumps all four to the same version and releases them in one PR even when a commit touched only one plugin. This is what makes "one shared version line" real (verified against release-please docs: components are component names; the plugin picks the highest version and syncs all group members).
- **`{plugin}--v{version}` tags** via top-level `include-component-in-tag: true` + `tag-separator: "--"`, with each package's `component` = its plugin name.
- **Four packages** keyed `plugins/<name>`, each `release-type: simple`, pre-1.0 bump flags preserved.
- **Each plugin.json `$.version`** bumped via `extra-files`; **dependency pins bump too** via `extra-files` jsonpath into the `dependencies` array (compose/conduct → notation; symphonize → compose+conduct). Under linked-versions all four share the version, so the pins resolve to the same shared version.
- `.release-please-manifest.json` re-keyed to the four package paths at `0.1.39`.

## Floating major tag / adopter ref
`update-major-tag.yml` gated with `if: startsWith(github.ref_name, 'notation--v')` — only notation moves a floating major (`notation--v0`), since only notation's reusable `governance-lint.yml` is referenced cross-repo by a git ref; compose/conduct/symphonize reach adopters via marketplace installs. Adopter ref updated `@v1` → `@notation--v0` consistently in `init.md`, `README.md`, `SPEC.md`.

## Verified locally
- Config + manifest valid JSON; manifest keys match config package keys.
- All four dependency jsonpaths resolve to the correct deps (compose[0]=notation, conduct[0]=notation, symphonize[0]=compose, [1]=conduct).
- `linked-versions` shape confirmed against docs.
- extra-files path resolution is package-dir-relative (proven by the prior working config, which used package `.` with a repo-root-relative path).
- `update-major-tag` major extraction: `notation--v0.2.0` → `notation--v0`.

## Only a live release PR can confirm (nothing auto-publishes — release PR is human-reviewed)
- That release-please's `json` updater applies array-indexed jsonpath (`$.dependencies[N].version`). If it doesn't, the dep pins simply won't bump on release — a contained, review-visible issue, not a broken publish.
- The end-to-end grouped PR + four tag strings.

## Governance
- ROADMAP: "Coordinated release" section removed — only the two parked sections (orchestration-loop, scaffolding-freshness) remain.
- SPEC: `§spec:plugin-packaging` / `§spec:governance-schema` / `§spec:notation-contract` kept `in progress` — the config is in place but the coordinated-release *behavior* isn't observable until the first release runs; they flip to `complete` once a real release validates the pipeline.

## Gates
- **Security review:** clean — declarative config + docs; `update-major-tag` change only narrows execution (`if` guard), no permission/token/trigger change.
- **/simplify:** n/a (config/JSON/YAML only).

> Run /review --comment to post code-quality findings as PR comments.