### PR TITLE
ci(governance-lint): exclude CHANGELOG from linting per the notation contract

### DIFF
--- a/.github/workflows/governance-lint.yml
+++ b/.github/workflows/governance-lint.yml
@@ -30,7 +30,6 @@ jobs:
             **/ROADMAP.md
             **/README.md
             **/REQUIREMENTS.md
-            **/CHANGELOG.md
 
       - name: Validate SPEC.md status lines
         run: |
@@ -185,34 +184,6 @@ jobs:
           fi
 
           echo "All REQUIREMENTS.md headings have §req: slugs"
-
-      - name: Validate CHANGELOG.md structure
-        run: |
-          errors=0
-          for changelog in $(find . -name 'CHANGELOG.md' -not -path './.git/*' | sort); do
-            echo "Checking $changelog"
-
-            # Must have an [Unreleased] section
-            if ! grep -qE '^## \[Unreleased\]' "$changelog"; then
-              echo "::error file=${changelog}::Missing ## [Unreleased] section"
-              errors=$((errors + 1))
-            fi
-
-            # Every ## heading must match [Unreleased] or [N.N.N] (with optional link)
-            while IFS= read -r line; do
-              if ! echo "$line" | grep -qE '^## \[(Unreleased|[0-9]+\.[0-9]+\.[0-9]+)\]'; then
-                echo "::error file=${changelog}::Invalid version heading: $line"
-                errors=$((errors + 1))
-              fi
-            done < <(grep -E '^## ' "$changelog" | tr -d '\r')
-          done
-
-          if [ "$errors" -gt 0 ]; then
-            echo "$errors CHANGELOG.md structure error(s) found"
-            exit 1
-          fi
-
-          echo "All CHANGELOG.md files have valid structure"
 
       - name: Validate cross-document references
         run: |


### PR DESCRIPTION
**Unblocks the first coordinated release PR (#155), which fails governance-lint.**

## Root cause
release-please generates a per-plugin `CHANGELOG.md` for each of the four plugins. Those files don't carry a `## [Unreleased]` section (release-please uses a `## [X.Y.Z]` heading immediately), so the workflow's `Validate CHANGELOG.md structure` step fails them: `4 CHANGELOG.md structure error(s) found`.

This check **contradicts `§spec:notation-contract`**, which already states:
> CHANGELOG.md is excluded: release-please generates it, so enforcing its shape fights the generator.

The workflow was enforcing exactly what the spec says not to. Classic governance-consistency drift — the check predated the spec's exclusion and was never removed.

## Fix
Align the workflow with the spec by excluding CHANGELOG from governance-lint:
- Removed `**/CHANGELOG.md` from the markdownlint globs.
- Removed the `Validate CHANGELOG.md structure` step.

No spec change needed — this makes the workflow match the contract. Applies to the reusable workflow, so adopters using release-please with per-package changelogs get the same fix.

## After this merges
release-please re-runs on the push to main and re-checks #155 — governance-lint will pass, and the (validated) coordinated release can proceed.

> Run /review --comment to post code-quality findings as PR comments.