### PR TITLE
docs: reconcile governance docs after the 0.2.0 four-plugin release

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,22 +5,22 @@
 ### §road:migrate-orchestrate-to-goal
 
 Replace `/ralph-loop:ralph-loop` with `/goal` in
-`plugins/symphonize/commands/orchestrate.md`, and retire residual ralph-loop
-coupling in `plugins/symphonize/commands/clean.md` (flag-file mode
-auto-detect), `plugins/symphonize/protocols/batch-agent.md`, `README.md`,
+`plugins/conduct/commands/orchestrate.md`, and retire residual ralph-loop
+coupling in `plugins/conduct/commands/clean.md` (flag-file mode
+auto-detect), `plugins/conduct/protocols/batch-agent.md`, `README.md`,
 `§spec:unattended-flag-passthrough`, and the known-issue note in
 `§spec:progress-file-location`. §spec:orchestration-loop
 
 **Verify:** From a project with a populated ROADMAP section, run
-`/symphonize:orchestrate`. Confirm: (1) it first invokes
-`/symphonize:clean --lite`; (2) it sets an active `/goal`, visible
+`/conduct:orchestrate`. Confirm: (1) it first invokes
+`/conduct:clean --lite`; (2) it sets an active `/goal`, visible
 via `/goal` with no arguments, whose condition targets section
-completion; (3) `/symphonize:next --unattended` runs and produces
+completion; (3) `/conduct:next --unattended` runs and produces
 at least one PR; (4) the goal clears automatically once the
 section reports all unblocked workstreams attempted. In a second
-session in the same project, run `/symphonize:plan` and confirm
+session in the same project, run `/compose:plan` and confirm
 no stop-hook directives fire from ralph-loop. Finally,
-`grep -r 'ralph' plugins/symphonize/ README.md SPEC.md` shall
+`grep -r 'ralph' plugins/conduct/ README.md SPEC.md` shall
 return no matches in active code paths (CHANGELOG.md may retain
 historical references).
 
@@ -29,14 +29,12 @@ historical references).
 ### §road:scaffold-consumer-dependabot
 
 Add a `.github/dependabot.yml` (`github-actions`) to the files
-`/symphonize:init` scaffolds, and document the scaffold-current-state /
-delegate-freshness contract in `plugins/symphonize/commands/init.md`.
+`/notation:init` scaffolds, and document the scaffold-current-state /
+delegate-freshness contract in `plugins/notation/commands/init.md`.
 §spec:scaffold-freshness
 
-**Verify:** a repo scaffolded by `/symphonize:init` contains a
+**Verify:** a repo scaffolded by `/notation:init` contains a
 `.github/dependabot.yml` enabling weekly `github-actions` updates;
-`plugins/symphonize/commands/init.md` and §spec:scaffold-freshness agree on
+`plugins/notation/commands/init.md` and §spec:scaffold-freshness agree on
 the contract; governance-lint passes. The dependabot scaffolding lives with
-the `init` scaffolder — `plugins/symphonize/commands/init.md` today, the
-notation plugin once the
-decomposition (§spec:governance-schema) builds it out.
+the `init` scaffolder, now in `plugins/notation/commands/init.md`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -690,7 +690,7 @@ and similar tools already resolve config by walking up the directory
 tree. Symphonize delegates to the linter's native scoping.
 
 ## Plugin decomposition §spec:governance-schema
-*Status: in progress*
+*Status: complete*
 
 Symphonize is one repository publishing one plugin marketplace with four
 plugins — each independently installable, all sharing one coordinated
@@ -764,12 +764,10 @@ on its own side; that seam stays unbuilt until a second schema exists.
   installation. Separate repositories would add cross-repo coordination with
   no adoption benefit.
 
-### Where today's CONVENTIONS.md content goes
+### Where the former CONVENTIONS.md content went
 
 The former shared `CONVENTIONS.md` bundled three contracts the
-decomposition separates. The content split has landed (the file is
-deleted); the plugin restructure that gives each group its own plugin
-home is still pending:
+decomposition separated (the file is deleted):
 
 - **Structural grammar** → notation enforces it; the linter is its
   executable form, so notation ships no per-repo conventions document.
@@ -808,7 +806,7 @@ home is still pending:
   difference is accepted.
 
 ## Plugin packaging and distribution §spec:plugin-packaging
-*Status: in progress*
+*Status: complete*
 
 The decomposition (§spec:governance-schema) ships as one Claude Code plugin
 marketplace named `symphonize`, declaring four plugins — `notation`,
@@ -865,25 +863,18 @@ always writes a workflow ref that exists and matches.
 
 Installed plugins are copied into `~/.claude/plugins/cache/` and cannot
 read files outside their own directory — `../` into a sibling plugin fails.
-Most of today's shared `CONVENTIONS.md` content becomes single-owner under
-the decomposition: authoring methodology in compose's commands, process
-discipline in conduct's commands and `protocols/batch-agent.md`, the
-structural grammar in notation's linter. The residual that several commands
-duplicate verbatim — the governance-root resolution algorithm — lives once
-under `fragments/` and is **assembled** into each consuming command file
-by `tools/assemble-fragments.sh`, between `<!-- assembled:<name> -->`
-markers. Each consumer's own surrounding context (its heading, the files it
-reads and writes, its upstream-context paragraph) stays hand-authored
-outside the markers. CI re-runs the build then `git diff --exit-code`, so a
-committed command file that drifts from a fresh assembly fails the job. Each
-cached plugin stays self-contained while the fragment keeps one source of
-truth. (The `§`-slug grammar is not duplicated as one identical block — it
-appears as command-specific format guidance — so it is not a fragment.)
+So the residual that several commands duplicate verbatim — the
+governance-root resolution algorithm — lives once under `fragments/` and is
+assembled into each consuming command file by a build step, with CI failing
+on any drift from a fresh assembly. Each cached plugin stays self-contained
+while the fragment keeps one source of truth. (The `§`-slug grammar is
+command-specific guidance, not one verbatim block, so it is not a fragment.)
+The marker and build mechanics live in `fragments/README.md`.
 
 **Why a build step, not symlinks:** a symlink into a sibling plugin
 resolves at install-time copy and dangles in the cache. Assembly resolves
-at commit/publish time, leaving each cached plugin self-contained, and the
-drift check prevents the divergence a manual copy would invite.
+at commit time, leaving each cached plugin self-contained, and the drift
+check prevents the divergence a manual copy would invite.
 
 ### Rejected alternatives
 
@@ -909,7 +900,7 @@ drift check prevents the divergence a manual copy would invite.
   adopters of a single layer ask for `feedback`.
 
 ## Notation contract §spec:notation-contract
-*Status: in progress*
+*Status: complete*
 
 notation defines what a well-formed governance document *is*: the
 governance file formats, the `§req:`/`§spec:`/`§road:` slug rules, the
@@ -937,10 +928,9 @@ prevent.
   `##` SPEC heading; a `§`-slug on every `##` SPEC/REQUIREMENTS and `###`
   ROADMAP heading; and resolution of every `§`-reference to a defined slug,
   code spans exempt — a dangling reference fails the job. Vale runs when a
-  `.vale.ini` exists, else is a silent no-op. CHANGELOG.md is excluded from
-  the status-line and slug checks (release-please generates it, so enforcing
-  its shape fights the generator); the workflow validates only its
-  `[Unreleased]`/`[N.N.N]` version-heading structure.
+  `.vale.ini` exists, else is a silent no-op. CHANGELOG.md is excluded
+  entirely (markdownlint and the structural checks both skip it):
+  release-please generates it, so enforcing its shape fights the generator.
 - These checks already run in symphonize's `governance-lint.yml`, which
   notation now owns; the decomposition re-homes them rather than rebuilding
   them.


### PR DESCRIPTION
`/conduct:clean` (full mode) post-merge reconciliation after the four-plugin decomposition shipped as **0.2.0**.

## SPEC.md — status flips + match-reality fixes
The decomposition is built and released, so the three sections held `in progress` pending a real release move to **`complete`**:
- `§spec:governance-schema`, `§spec:plugin-packaging`, `§spec:notation-contract` → `complete`.

Two statements that became **false** are corrected (the point of the reconciliation):
- governance-schema said the plugin restructure "is still pending" → it shipped; reworded the CONVENTIONS-content subsection to past tense.
- notation-contract said governance-lint "validates only its `[Unreleased]`/`[N.N.N]` version-heading structure" → **#156 removed that check**; CHANGELOG is now excluded *entirely*.

Light compression on plugin-packaging's fragment-assembly subsection — trimmed the marker/script mechanics (now pointed at `fragments/README.md`), kept the rationale (cache isolation, build-not-symlinks).

## ROADMAP.md — match-reality fixes
The two parked workstreams carried stale `plugins/symphonize/` paths and `/symphonize:*` namespaces from before the carve-outs:
- `migrate-orchestrate-to-goal`: `orchestrate.md`/`clean.md`/`batch-agent.md` → `plugins/conduct/...`; Verify commands → `/conduct:*`, `/compose:plan`.
- `scaffold-consumer-dependabot`: `/symphonize:init` → `/notation:init`; `init.md` → `plugins/notation/...`; dropped the "once the decomposition builds it out" future-tense (it's built).

## Git/CHANGELOG housekeeping
- Stale local branches pruned; merged-PR remote branches already auto-deleted. **#109 left open** (unrelated pre-existing PR, not from this loop).
- release-please now manages **per-plugin** CHANGELOGs (`plugins/*/CHANGELOG.md`, generated at 0.2.0). The root `CHANGELOG.md` is now orphaned (no root package) — left as historical; whether to remove it is a separate call.

markdownlint clean; all `§spec:`/`§road:` references resolve.

## Deliberately NOT done (flagged as follow-up)
Four older sections — `§spec:reusable-ci`, `§spec:self-contained-conventions`, `§spec:project-scaffolding`, `§spec:dogfooding` — are explicitly *superseded* by `§spec:governance-schema` and now describe the pre-decomposition monolith. Removing/reconciling them touches cross-references (e.g. `§spec:scaffold-freshness` cites them), so it's a deliberate edit, not a mechanical clean step. Likewise `§spec:plugin-commands` still catalogs `/symphonize:*`.

> Run /review --comment to post code-quality findings as PR comments.