### PR TITLE
feat: batch — slug-on-every-heading addressing grammar

### DIFF
--- a/.github/workflows/governance-lint.yml
+++ b/.github/workflows/governance-lint.yml
@@ -125,158 +125,151 @@ jobs:
 
           echo "All required README headings present for type '$readme_type'"
 
-      - name: Validate SPEC.md heading slugs
+      # Heading addressing grammar (SPEC §spec:heading-addressing).
+      #
+      # A §<prefix>:slug suffix is REQUIRED on every ## heading in SPEC.md
+      # (§spec:), REQUIREMENTS.md (§req:), and ROADMAP.md (§road:). A heading
+      # deeper than ## MAY carry a slug — optional, but when present it joins
+      # the namespace. The # h1 title is exempt.
+      #
+      # The namespace is flat and unique: each slug is unique within its prefix
+      # across the governance root; a duplicate definition fails. Every
+      # §-reference resolves to exactly one defined slug (zero or multiple
+      # matches fail). Code spans and fenced blocks are exempt.
+      #
+      # Positional addressing is rejected: a heading whose text begins with a
+      # numeric ordinal hard-fails, as does any §<number> reference.
+      - name: Validate heading addressing grammar
         run: |
           errors=0
-          for specfile in $(find . -name 'SPEC.md' -not -path './.git/*' | sort); do
-            echo "Checking $specfile"
-            while IFS= read -r line; do
-              if ! echo "$line" | grep -qE '§spec:[a-z0-9-]+'; then
-                echo "::error file=${specfile}::Heading missing §spec: slug: $line"
-                errors=$((errors + 1))
-              fi
-            done < <(grep -E '^## ' "$specfile" | tr -d '\r')
-          done
+          defs_file=$(mktemp)   # one "prefix:slug" per line (definitions)
 
-          if [ "$errors" -gt 0 ]; then
-            echo "$errors SPEC.md heading slug error(s) found"
-            exit 1
-          fi
+          # Map a governance filename to its required ## slug prefix.
+          prefix_for() {
+            case "$1" in
+              SPEC.md) echo "spec" ;;
+              REQUIREMENTS.md) echo "req" ;;
+              ROADMAP.md) echo "road" ;;
+              *) echo "" ;;
+            esac
+          }
 
-          echo "All SPEC.md headings have §spec: slugs"
+          govfiles=$(find . \( -name 'SPEC.md' -o -name 'ROADMAP.md' -o -name 'REQUIREMENTS.md' \) -not -path './.git/*' | sort)
 
-      - name: Validate ROADMAP.md heading slugs
-        run: |
-          errors=0
-          for roadmapfile in $(find . -name 'ROADMAP.md' -not -path './.git/*' | sort); do
-            echo "Checking $roadmapfile"
-            while IFS= read -r line; do
-              if ! echo "$line" | grep -qE '^### §road:[a-z0-9-]+'; then
-                echo "::error file=${roadmapfile}::Heading missing §road: slug pattern: $line"
-                errors=$((errors + 1))
-              fi
-            done < <(grep -E '^### ' "$roadmapfile" | tr -d '\r')
-          done
-
-          if [ "$errors" -gt 0 ]; then
-            echo "$errors ROADMAP.md heading slug error(s) found"
-            exit 1
-          fi
-
-          echo "All ROADMAP.md headings have §road: slugs"
-
-      - name: Validate REQUIREMENTS.md heading slugs
-        run: |
-          errors=0
-          for reqfile in $(find . -name 'REQUIREMENTS.md' -not -path './.git/*' | sort); do
-            echo "Checking $reqfile"
-            while IFS= read -r line; do
-              if ! echo "$line" | grep -qE '§req:[a-z0-9-]+'; then
-                echo "::error file=${reqfile}::Heading missing §req: slug: $line"
-                errors=$((errors + 1))
-              fi
-            done < <(grep -E '^## ' "$reqfile" | tr -d '\r')
-          done
-
-          if [ "$errors" -gt 0 ]; then
-            echo "$errors REQUIREMENTS.md heading slug error(s) found"
-            exit 1
-          fi
-
-          echo "All REQUIREMENTS.md headings have §req: slugs"
-
-      - name: Validate cross-document references
-        run: |
-          errors=0
-          slugs_file=$(mktemp)
-
-          # Extract §prefix:slug from heading lines across all governance roots.
-          # §spec: from ## headings in all SPEC.md files
-          for f in $(find . -name 'SPEC.md' -not -path './.git/*'); do
-            grep -E '^## ' "$f" | grep -oE '§spec:[a-z0-9-]+' >> "$slugs_file" || true
-          done
-
-          # §road: from ### headings in all ROADMAP.md files
-          for f in $(find . -name 'ROADMAP.md' -not -path './.git/*'); do
-            grep -E '^### ' "$f" | grep -oE '§road:[a-z0-9-]+' >> "$slugs_file" || true
-          done
-
-          # §req: from ## headings in all REQUIREMENTS.md files
-          for f in $(find . -name 'REQUIREMENTS.md' -not -path './.git/*'); do
-            grep -E '^## ' "$f" | grep -oE '§req:[a-z0-9-]+' >> "$slugs_file" || true
-          done
-
-          echo "Defined slugs:"
-          cat "$slugs_file"
-
-          # Scan governance files for references and validate them
-          govfiles=$(find . -name 'SPEC.md' -o -name 'ROADMAP.md' -o -name 'CONVENTIONS.md' -o -name 'REQUIREMENTS.md' | grep -v './.git/' | sort)
+          # Pass 1 — per heading: enforce required ## slug, reject positional
+          # ordinals, and collect slug definitions (any heading depth >= ##).
           for govfile in $govfiles; do
+            echo "Checking $govfile"
+            base=$(basename "$govfile")
+            prefix=$(prefix_for "$base")
+            [ -z "$prefix" ] && continue
 
             lineno=0
             in_fenced_block=false
             while IFS= read -r line; do
               lineno=$((lineno + 1))
 
-              # Track fenced code blocks
               if echo "$line" | grep -qE '^```'; then
-                if $in_fenced_block; then
-                  in_fenced_block=false
-                else
-                  in_fenced_block=true
+                if $in_fenced_block; then in_fenced_block=false; else in_fenced_block=true; fi
+                continue
+              fi
+              $in_fenced_block && continue
+
+              # Heading lines only (## or deeper; the # h1 title is exempt).
+              echo "$line" | grep -qE '^##+ ' || continue
+
+              # Positional addressing: heading text begins with a numeric
+              # ordinal (## 8. Machine control, ### 3.1 Foo). A topic name that
+              # merely starts with a digit (## 3D visualization) passes.
+              if echo "$line" | grep -qE '^#+ [0-9]+(\.[0-9]+)*[. ]'; then
+                echo "::error file=${govfile},line=${lineno}::Positional heading rejected (numeric ordinal): $line"
+                errors=$((errors + 1))
+              fi
+
+              # Collect any slug defined on this heading (any prefix).
+              heading_slugs=$(echo "$line" | grep -oE '§(spec|req|road):[a-z0-9-]+' || true)
+
+              # Every ## heading must carry the doc's required prefix slug.
+              if echo "$line" | grep -qE '^## '; then
+                if ! echo "$line" | grep -qE "§${prefix}:[a-z0-9-]+"; then
+                  echo "::error file=${govfile},line=${lineno}::## heading missing §${prefix}: slug: $line"
+                  errors=$((errors + 1))
                 fi
-                continue
               fi
 
-              # Skip lines inside fenced code blocks
-              if $in_fenced_block; then
+              for s in $heading_slugs; do
+                echo "${s#§}" >> "$defs_file"
+              done
+            done < <(tr -d '\r' < "$govfile")
+          done
+
+          # Uniqueness: each prefix:slug defined exactly once.
+          dupes=$(sort "$defs_file" | uniq -d)
+          if [ -n "$dupes" ]; then
+            while IFS= read -r d; do
+              [ -z "$d" ] && continue
+              echo "::error::Duplicate slug definition: §${d} (defined more than once)"
+              errors=$((errors + 1))
+            done <<< "$dupes"
+          fi
+
+          echo "Defined slugs:"
+          sort -u "$defs_file" | sed 's/^/  §/'
+
+          # Pass 2 — references: every §-reference resolves to exactly one
+          # definition; numeric references are rejected. Code spans and fenced
+          # blocks are exempt. A heading's own definition is not a reference.
+          for govfile in $govfiles; do
+            lineno=0
+            in_fenced_block=false
+            while IFS= read -r line; do
+              lineno=$((lineno + 1))
+
+              if echo "$line" | grep -qE '^```'; then
+                if $in_fenced_block; then in_fenced_block=false; else in_fenced_block=true; fi
                 continue
               fi
+              $in_fenced_block && continue
 
-              # Strip inline code spans before scanning for references
+              # Strip inline code spans before scanning.
               stripped=$(echo "$line" | sed 's/`[^`]*`//g')
 
-              # Find all §prefix:slug references on the stripped line
-              refs=$(echo "$stripped" | grep -oE '§(spec|req|road):[a-z0-9-]+' || true)
-              if [ -z "$refs" ]; then
-                continue
+              # Numeric reference (§8.9, §3): positional addressing, rejected.
+              if echo "$stripped" | grep -qE '§[0-9]'; then
+                echo "::error file=${govfile},line=${lineno}::Positional reference rejected (numeric address): $line"
+                errors=$((errors + 1))
               fi
 
+              # On a heading line, the prefix:slug pair(s) at the END are this
+              # heading's own definition(s), not references — drop them so a
+              # heading does not "reference" itself.
+              scan="$stripped"
+              if echo "$stripped" | grep -qE '^##+ '; then
+                scan=$(echo "$stripped" | sed -E 's/§(spec|req|road):[a-z0-9-]+//g')
+              fi
+
+              refs=$(echo "$scan" | grep -oE '§(spec|req|road):[a-z0-9-]+' || true)
+              [ -z "$refs" ] && continue
+
               for ref in $refs; do
-                prefix="${ref%%:*}"
-                prefix="${prefix#§}"
-
-                # Skip heading definitions (not references)
-                basename=$(basename "$govfile")
-                case "$prefix" in
-                  spec)
-                    if [ "$basename" = "SPEC.md" ] && echo "$line" | grep -q '^## '; then
-                      continue
-                    fi ;;
-                  road)
-                    if [ "$basename" = "ROADMAP.md" ] && echo "$line" | grep -q '^### '; then
-                      continue
-                    fi ;;
-                  req)
-                    if [ "$basename" = "REQUIREMENTS.md" ] && echo "$line" | grep -q '^## '; then
-                      continue
-                    fi ;;
-                esac
-
-                # Check that the reference resolves to a defined slug
-                if ! grep -qxF "$ref" "$slugs_file"; then
-                  echo "::error file=${govfile},line=${lineno}::Dangling reference ${ref} — no matching heading found"
+                key="${ref#§}"
+                count=$(grep -cxF "$key" "$defs_file" || true)
+                if [ "$count" -eq 0 ]; then
+                  echo "::error file=${govfile},line=${lineno}::Dangling reference ${ref} — no matching heading"
+                  errors=$((errors + 1))
+                elif [ "$count" -gt 1 ]; then
+                  echo "::error file=${govfile},line=${lineno}::Ambiguous reference ${ref} — resolves to ${count} headings"
                   errors=$((errors + 1))
                 fi
               done
             done < <(tr -d '\r' < "$govfile")
           done
 
-          rm -f "$slugs_file"
+          rm -f "$defs_file"
 
           if [ "$errors" -gt 0 ]; then
-            echo "$errors cross-document reference error(s) found"
+            echo "$errors heading-addressing error(s) found"
             exit 1
           fi
 
-          echo "All cross-document references resolved"
+          echo "Heading addressing grammar valid"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # symphonize — Roadmap
 
-## Orchestration loop via /goal
+## Orchestration loop via /goal §road:orchestration-loop
 
-### §road:migrate-orchestrate-to-goal
+### Migrate orchestrate to /goal §road:migrate-orchestrate-to-goal
 
 Replace `/ralph-loop:ralph-loop` with `/goal` in
 `plugins/conduct/commands/orchestrate.md`, and retire residual ralph-loop
@@ -24,9 +24,9 @@ no stop-hook directives fire from ralph-loop. Finally,
 return no matches in active code paths (CHANGELOG.md may retain
 historical references).
 
-## Scaffolding freshness
+## Scaffolding freshness §road:scaffolding-freshness
 
-### §road:scaffold-consumer-dependabot
+### Scaffold consumer dependabot §road:scaffold-consumer-dependabot
 
 Add a `.github/dependabot.yml` (`github-actions`) to the files
 `/notation:init` scaffolds, and document the scaffold-current-state /
@@ -38,41 +38,3 @@ delegate-freshness contract in `plugins/notation/commands/init.md`.
 `plugins/notation/commands/init.md` and §spec:scaffold-freshness agree on
 the contract; governance-lint passes. The dependabot scaffolding lives with
 the `init` scaffolder, now in `plugins/notation/commands/init.md`.
-
-## Heading addressing grammar
-
-### §road:ordinal-prose-vale
-
-Add an ordinal-prose heading warning to the Vale `Requirements` style
-(`styles/Requirements/`). §spec:heading-addressing
-
-### §road:notation-scaffold-grammar
-
-Update the `/notation:init` skeletons to emit `##`-mandatory, suffix-placed
-slugs in all three governance files (`plugins/notation/commands/init.md`).
-§spec:heading-addressing
-
-### §road:authoring-grammar-sync
-
-Revise the compose authoring formats and the notation lint scope text to the
-suffix-placement, optional-deeper-slug grammar
-(`plugins/compose/commands/plan.md`, `plugins/compose/commands/roadmap.md`,
-`plugins/notation/commands/lint.md`). §spec:heading-addressing
-
-### §road:heading-addressing-lint
-
-Extend `governance-lint.yml` to enforce the addressing grammar and migrate
-`ROADMAP.md` to conform (`.github/workflows/governance-lint.yml`, `ROADMAP.md`).
-§spec:heading-addressing. Depends on §road:notation-scaffold-grammar and
-§road:authoring-grammar-sync — the scaffolder and authoring docs describe the
-grammar before CI enforces it, per §spec:governance-consistency.
-
-**Verify:** on a scratch branch, push governance-doc edits and confirm
-governance-lint (CI) behaves as specified: a `## Foo` ROADMAP section with no
-`§road:` slug fails; two headings defining the same `§spec:` slug fail the
-uniqueness check; a heading `## 9. Numbered thing` fails; a `§9.9` reference
-outside a code span fails while the same text inside backticks passes; a
-`### Stage 1 — x` heading draws a Vale warning, not a failure; and
-symphonize's own `SPEC.md`, `ROADMAP.md`, and `REQUIREMENTS.md` pass clean.
-Run `/notation:init` in an empty directory and confirm the scaffolded
-`ROADMAP.md` uses `## Title §road:slug` suffix placement.

--- a/SPEC.md
+++ b/SPEC.md
@@ -652,9 +652,8 @@ concerns. Spending three agent spawns on prose is noise.
 Roadmap workstreams are thin pointers into SPEC.md. A workstream
 description is one sentence stating the deliverable and affected
 file(s), plus a `§spec:` citation. `**Verify:**` blocks remain at
-the section level. The `### §road:slug` heading format is retained.
-§spec:heading-addressing revises this to suffix placement; until it ships,
-the slug-first format is enforced.
+the section level. Workstream headings use suffix placement
+(`### <Title> §road:slug`) per §spec:heading-addressing.
 
 **Why:** verbose workstream descriptions duplicate the spec and
 diverge when the spec is updated. The batch agent reads SPEC.md
@@ -909,9 +908,8 @@ governance file formats, the `§req:`/`§spec:`/`§road:` slug rules, the
 status-line format and placement, the cross-reference rules, and the
 governance-root definition. The contract is content-agnostic — it governs
 document *structure*, not authoring methodology (compose's) or development
-process (conduct's). §spec:heading-addressing revises the slug coverage and
-placement rules; until it ships, the rules below describe the enforced
-contract.
+process (conduct's). §spec:heading-addressing defines the slug coverage and
+placement rules this contract enforces.
 
 ### Expressed, not distributed
 
@@ -929,10 +927,12 @@ prevent.
 
 - governance-lint enforces, on every invocation with no opt-in switches:
   markdownlint over the governance documents; a valid status line on every
-  `##` SPEC heading; a `§`-slug on every `##` SPEC/REQUIREMENTS and `###`
-  ROADMAP heading; and resolution of every `§`-reference to a defined slug,
-  code spans exempt — a dangling reference fails the job. Vale runs when a
-  `.vale.ini` exists, else is a silent no-op. CHANGELOG.md is excluded
+  `##` SPEC heading; the slug grammar of §spec:heading-addressing (a
+  `§`-slug suffix on every `##` heading, unique within its prefix, every
+  `§`-reference resolving to exactly one definition, positional addressing
+  rejected); code spans and fenced blocks exempt from reference resolution.
+  Vale runs when a `.vale.ini` exists, else is a silent no-op. CHANGELOG.md
+  is excluded
   entirely (markdownlint and the structural checks both skip it):
   release-please generates it, so enforcing its shape fights the generator.
 - These checks already run in symphonize's `governance-lint.yml`, which
@@ -1171,7 +1171,7 @@ current view of the repo. §req:modular-adoption
   alternative (no fresh state at all) is strictly worse.
 
 ## Heading addressing §spec:heading-addressing
-*Status: not started*
+*Status: complete*
 
 A governance document addresses its units by slug. Today only top-level
 sections carry slugs — `##` in SPEC/REQUIREMENTS, `###` in ROADMAP — so a

--- a/plugins/compose/commands/plan.md
+++ b/plugins/compose/commands/plan.md
@@ -88,7 +88,9 @@ Rules:
   placement and values via governance-lint.
 - Headings use slug-style `##` (unnumbered). `## Plugin commands` not
   `## 1. Plugin commands`. Each `##` heading carries a `§spec:slug`
-  suffix, and cites `§req:` sources inline.
+  suffix (title then slug), and cites `§req:` sources inline. A heading
+  deeper than `##` may carry a `§spec:slug` suffix; it is required only
+  to make that heading referenceable.
 
 Reference: Alistair Mavin et al., "EARS (Easy Approach to Requirements
 Syntax)" (2009).

--- a/plugins/compose/commands/roadmap.md
+++ b/plugins/compose/commands/roadmap.md
@@ -62,16 +62,17 @@ The roadmap is a work queue, not a history log. It should stay small.
 Rules:
 
 - Derive from SPEC.md. Every roadmap item traces to a spec gap.
-- Un-numbered `##` sections in build-dependency order. Earlier sections
-  validate assumptions that later sections depend on.
+- Un-numbered `##` sections in build-dependency order, each carrying a
+  `§road:slug` suffix (title then slug). Earlier sections validate
+  assumptions that later sections depend on.
 - New work enters at the tail. Completed work leaves from the head.
 - When a section or workstream completes, delete it from the roadmap.
   Conventional commit messages feed release-please, which records the
   history in CHANGELOG.md. The roadmap does not duplicate that record.
   Presence in the roadmap means the work is not done.
-- Workstreams are `### §road:slug` headings under each section.
-  Slugs are lowercase, hyphenated, grep-friendly
-  (e.g. `§road:delete-noise-tests`, `§road:extract-protocol`).
+- Workstreams are `### <Title> §road:slug` headings (suffix placement —
+  title then slug) under each section. Slugs are lowercase, hyphenated,
+  grep-friendly (e.g. `§road:delete-noise-tests`, `§road:extract-protocol`).
 - Size each workstream to fit one agent session (~200k tokens).
   If a workstream is too large, split it.
 - Blocked workstreams stay under the section they belong to, annotated
@@ -143,7 +144,9 @@ backpressure proportional to the gap.
    infrastructure workstreams first, surface workstream last. The
    surface workstream is the integration point that wires
    everything beneath it into a testable feature.
-   - Each workstream gets a `### §road:slug` heading, one sentence
+   - Each section gets a `## <Title> §road:slug` heading (suffix
+     placement). Each workstream gets a `### <Title> §road:slug`
+     heading (suffix placement — title then slug), one sentence
      stating the deliverable and the affected file(s), a `§spec:`
      citation, and explicit dependency annotations. Rationale,
      procedures, and implementation detail live in the cited spec

--- a/plugins/notation/commands/init.md
+++ b/plugins/notation/commands/init.md
@@ -29,6 +29,10 @@ Create at the governance root (CWD):
   ```markdown
   # <project-name> — Specification
 
+  <!-- Each ## section carries a §spec:slug suffix (title then slug). -->
+  <!-- Headings deeper than ## may carry a slug — required only to make -->
+  <!-- them referenceable. -->
+
   ## <first section> §spec:<slug>
   *Status: not started*
 
@@ -38,15 +42,23 @@ Create at the governance root (CWD):
   ```markdown
   # <project-name> — Roadmap
 
-  <!-- Sections in build-dependency order. -->
-  <!-- Workstreams as `- **slug**: description` bullets. -->
+  <!-- Sections in build-dependency order. Each ## section carries a -->
+  <!-- §road:slug suffix (title then slug). Workstreams are ### headings -->
+  <!-- in suffix form: ### <Title> §road:<slug>. -->
+
+  ## <first section> §road:<slug>
+
+  ### <first workstream> §road:<slug>
   ```
 - **REQUIREMENTS.md** — skeleton:
   ```markdown
   # <project-name> — Requirements
 
-  <!-- Problem-space document. Each ## section carries a §req:slug suffix. -->
-  <!-- Run /symphonize:discover to populate through a structured interview. -->
+  <!-- Problem-space document. Each ## section carries a §req:slug suffix -->
+  <!-- (title then slug). Run /compose:discover to populate through a -->
+  <!-- structured interview. -->
+
+  ## <first section> §req:<slug>
   ```
 - **CHANGELOG.md** — skeleton:
   ```markdown
@@ -114,6 +126,16 @@ Create at the governance root (CWD):
     - 'it is important to note'
     - 'at this point in time'
     - 'for the purpose of'
+  ```
+- **styles/Requirements/OrdinalHeadings.yml** — warns on ordinal-prose headings:
+  ```yaml
+  extends: existence
+  message: "Heading '%s' is numbered in prose. If the number is document structure, address by §slug instead; if it describes the system, keep it."
+  level: warning
+  scope: heading
+  nonword: true
+  tokens:
+    - '^(Stage|Phase|Step|Part|Pass|Round|Tier|Level|Iteration)\s+([0-9]+[a-z]?|[IVXivx]+)\b'
   ```
 
 ### CI workflows

--- a/plugins/notation/commands/lint.md
+++ b/plugins/notation/commands/lint.md
@@ -32,10 +32,14 @@ executable form is the reusable `governance-lint.yml` workflow
 **Scope difference:** this command runs markdownlint only — it checks
 markdown formatting (heading structure, line length, etc.). The CI
 workflow `governance-lint.yml` runs markdownlint plus the rest of the
-notation contract: SPEC.md status lines, `§spec:`/`§road:`/`§req:` slug
-formats, cross-document reference resolution (code spans exempt;
-dangling references fail), CHANGELOG.md structure, and README heading
-checks. To get the full validation suite, push and let CI run, or
-inspect `governance-lint.yml` directly.
+notation contract: SPEC.md status lines; a `§spec:`/`§road:`/`§req:`
+slug suffix on every `##` heading (deeper headings may carry one); a
+flat, unique slug namespace (a duplicate slug definition fails); every
+`§`-reference resolving to exactly one defined slug (code spans and
+fenced blocks exempt; zero or multiple matches fail); rejection of
+positional addressing (a heading beginning with a numeric ordinal, or
+any `§<number>` reference, hard-fails); CHANGELOG.md structure; and
+README heading checks. To get the full validation suite, push and let
+CI run, or inspect `governance-lint.yml` directly.
 
 $1

--- a/styles/Requirements/OrdinalHeadings.yml
+++ b/styles/Requirements/OrdinalHeadings.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Heading '%s' is numbered in prose. If the number is document structure, address by §slug instead; if it describes the system, keep it."
+level: warning
+scope: heading
+nonword: true
+tokens:
+  - '^(Stage|Phase|Step|Part|Pass|Round|Tier|Level|Iteration)\s+([0-9]+[a-z]?|[IVXivx]+)\b'


### PR DESCRIPTION
Implements the `Heading addressing grammar` ROADMAP section (`§spec:heading-addressing`, issue #161) as one vertical slice. Closes the governance pipeline for #161.

Fixes #161

## Workstreams (one commit each)

- **§road:ordinal-prose-vale** — `feat(notation): warn on ordinal-prose headings in Vale Requirements style`. New `styles/Requirements/OrdinalHeadings.yml` rule (warning) for headings beginning with an ordinal word + number (`Stage 1`, `Phase 2`, …).
- **§road:notation-scaffold-grammar** — `feat(notation): scaffold suffix-placed slugs on every ## heading`. `/notation:init` skeletons emit `§<prefix>:slug` suffixes on every `##` (ROADMAP `##` sections now slugged) and suffix-placed `### Title §road:slug` workstreams.
- **§road:authoring-grammar-sync** — `docs(compose,notation): sync authoring grammar to suffix-placed slugs`. Updated `compose/commands/plan.md` (deeper-optional slugs), `compose/commands/roadmap.md` (suffix placement, ROADMAP `##` slugs), `notation/commands/lint.md` (uniqueness + numeric-retirement scope).
- **§road:heading-addressing-lint** (surface) — `feat(notation): enforce slug-on-every-heading addressing grammar`. `governance-lint.yml` enforces: mandatory `##` slug all three docs, optional deeper slugs in the resolver union, per-prefix uniqueness, suffix placement, and positional-addressing hard-fails (numbered headings + `§<number>` refs). Atomically migrates `ROADMAP.md` to the new grammar; flips `§spec:heading-addressing` to *complete*.

## Verification

Local checks against the migrated docs (real CI runs the rewritten reusable workflow on this PR): markdownlint clean across SPEC/ROADMAP/REQUIREMENTS/README; every `##` carries its doc-type slug; no numbered headings; ROADMAP `###` all suffix-placed; all slugs unique; every `§`-reference resolves to exactly one definition. Security review: no findings. Phase 5a `/simplify` skip-eligible (diff is YAML + governance docs + Vale YAML + command markdown — all non-source).

## Reviewer notes

- The `§spec:heading-addressing` section is now *complete* — its forward-pointer notes in `§spec:notation-contract` and `§spec:thin-roadmap-workstreams` ("until it ships, the rules below describe the enforced contract") are now satisfied; worth a glance to confirm they read cleanly post-ship, or fold them in a follow-up reconciliation.
- Exercise the section's `**Verify:**` block: push a scratch governance edit and confirm the new lint fails an unslugged `## Foo` ROADMAP section, a duplicate slug, a `## 9. Numbered` heading, and a bare `§9.9` reference, and that `### Stage 1` only warns.

> Run /review --comment to post code-quality findings as PR comments.