### PR TITLE
docs: archive root CHANGELOG, point to per-plugin changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+> **Archived.** This is the changelog of the original single-plugin
+> `symphonize` (versions 0.1.1–0.1.39). Since 0.2.0 the project ships four
+> plugins, each with its own release-please-managed changelog under
+> `plugins/*/CHANGELOG.md` (`notation`, `compose`, `conduct`, `symphonize`) —
+> those are the current records. Nothing is appended to this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -426,20 +430,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * resolve markdownlint violations in governance files ([6a49443](https://github.com/repentsinner/symphonize/commit/6a49443666ba989ad11d8d0374e61193857e4104))
 * simplify /lint to just run markdownlint ([6780522](https://github.com/repentsinner/symphonize/commit/6780522f71c299c98f9d77a10e211ad9c814c790))
 * use './' for self-referencing plugin source ([be55681](https://github.com/repentsinner/symphonize/commit/be55681a955b3635ec19860e739e2af3a0642fe4))
-
-## [Unreleased]
-
-### Added
-
-- `/symphonize:lint` command — runs markdownlint on governance files locally
-- `/symphonize:init` command — scaffolds governance files, CI workflows, and pre-commit hooks
-- Reusable `governance-lint.yml` workflow (markdownlint, SPEC.md status lines, README headings)
-- Template workflows: release-please, auto-merge-release, update-major-tag
-- Pre-commit hook scaffolding via `.githooks/` and `core.hooksPath`
-- Governance files (SPEC.md, ROADMAP.md, CHANGELOG.md)
-- CI dogfooding own governance-lint workflow
-
-### Changed
-
-- README restructured: motivation before mechanics, added Opinions and Governance files sections
-- `/symphonize:clean --full` delegates to `/symphonize:lint` instead of inline markdownlint


### PR DESCRIPTION
Resolves the orphaned root `CHANGELOG.md` surfaced during `/conduct:clean`.

## Context

The root `CHANGELOG.md` holds the original **single-plugin** symphonize history — 39 releases, `0.1.1 → 0.1.39`. Since the 0.2.0 four-plugin decomposition, release-please manages a changelog **per plugin** (`plugins/{notation,compose,conduct,symphonize}/CHANGELOG.md`, currently 0.2.1), and the root file is not in release-please's package set — nothing writes to it. Its `[Unreleased]` block had gone stale, listing already-shipped work under **retired** `/symphonize:lint`, `/symphonize:init`, `/symphonize:clean` command names.

## Change (freeze + pointer)

- Remove the stale `[Unreleased]` block.
- Add a header note marking the file as the archived pre-0.2.0 monolith history and pointing to the per-plugin changelogs.
- Retain the full `0.1.x` release narrative as a browsable audit trail.

## Why not delete or move

- **Delete** would drop the only human-readable record of the `0.1.x` era (per-plugin changelogs start at 0.2.0; only git tags would remain).
- **Move into `plugins/symphonize/`** would misattribute shared monolith history to one of four heirs (release-please anchors *each* plugin to `--v0.1.39`) and inject manual content into a release-please-managed file.

## Verification

markdownlint clean; `[Unreleased]` removed; 39 release sections intact. Root-level change touches no `plugins/*` package, so release-please does not act on it. No conflict with open PR #160 (it does not touch CHANGELOG.md).