### PR TITLE
docs(ci): fix retired command name in dependabot comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   # Keep the GitHub Actions pinned in .github/workflows current. These
-  # workflow files are also the templates /symphonize:init copies into
+  # workflow files are also the templates /notation:init copies into
   # consuming repos, so keeping them fresh here keeps new scaffolds from
   # shipping stale action versions.
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Single-line follow-up surfaced while reviewing #160.

`.github/dependabot.yml` comment named the retired `/symphonize:init`; the init scaffolder is `/notation:init` since the 0.2.0 four-plugin decomposition. #160 migrates SPEC.md but is SPEC-scoped, so this comment was the one remaining stale `/symphonize:*` reference in the repo (outside the legitimate umbrella `/symphonize:feedback`/`/symphonize:yolo`).

Comment-only; no behavior change.