### PR TITLE
docs(spec): triage #167 — integration-ref resolution

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,3 +38,30 @@ delegate-freshness contract in `plugins/notation/commands/init.md`.
 `plugins/notation/commands/init.md` and §spec:scaffold-freshness agree on
 the contract; governance-lint passes. The dependabot scaffolding lives with
 the `init` scaffolder, now in `plugins/notation/commands/init.md`.
+
+## Integration-ref resolution §road:integration-ref-resolution
+
+### Resolve the integration trunk across conduct and compose §road:resolve-trunk
+
+Replace hardcoded `main` with a trunk resolved from the repository default
+branch across `plugins/conduct/commands/{next,review,clean}.md`,
+`plugins/conduct/protocols/batch-agent.md`, and
+`plugins/compose/commands/{triage,roadmap}.md`, and update the `main`-relative
+wording in §spec:clean-supersession-safety and §spec:repo-state-reconciliation.
+§spec:integration-ref. Reported in #167.
+
+### Base worktree sub-agents on the batch integration HEAD §road:worktree-base-ref
+
+Make the dispatch and batch-agent protocol pass the batch branch commit to each
+worktree sub-agent and base its work there rather than the default branch
+(`plugins/conduct/commands/next.md`, `plugins/conduct/protocols/batch-agent.md`).
+§spec:integration-ref. Depends on §road:resolve-trunk. Reported in #167.
+
+**Verify:** in a scratch repo whose default branch is `develop`, run
+`/conduct:next` on a populated ROADMAP and confirm the batch branch is cut from
+`develop` and the PR targets `develop` (no reference to a non-existent `main`).
+In a batch of two serial workstreams touching the same file, confirm the second
+sub-agent's worktree already contains the first workstream's integrated commit
+(its work builds on it without a cherry-pick conflict) and CI passes after each
+integration. `grep -rn 'origin/main' plugins/` returns no hardcoded trunk in
+active command and protocol paths.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1300,3 +1300,65 @@ is the placement and coverage change only. §req:modular-adoption
 - An explicit slug duplicates words from its heading when the author picks a slug
   that echoes the title. The duplication is benign — the slug is the stable
   identifier, deliberately allowed to differ — and avoidable with a short slug.
+
+## Integration-ref resolution §spec:integration-ref
+*Status: not started*
+
+symphonize's commands and the batch-agent protocol hardcode `main` as the
+integration branch: `git checkout -b … origin/main`, "verify main is current",
+`git log main..<branch>`, reading ROADMAP.md from `origin/main`, rebasing onto
+`origin/main`. Two failures follow, reported by an external adopter whose trunk
+is not `main`.
+
+A project whose trunk is `develop` — or anything other than `main` — targets the
+wrong branch in every command (§req:modular-adoption). And worktree-isolated
+sub-agents fork from the repository's default branch rather than the batch branch
+they should extend, so serial workstreams within one batch miss the planning
+foundation and each other's already-integrated work — producing the cherry-pick
+conflicts and CI breakage that contradict the vertical-slice execution model
+(§spec:vertical-first-batch-selection).
+
+### Observable behavior
+
+- **The integration trunk is resolved once, not hardcoded.** Commands and
+  protocols reference a single resolved trunk branch rather than the literal
+  `main`, defaulting to the repository's own default branch so a non-`main` trunk
+  works without per-command edits. The `main`-relative comparisons in
+  §spec:clean-supersession-safety and §spec:repo-state-reconciliation use the
+  resolved trunk.
+- **Worktree sub-agents descend from the batch integration HEAD, not the trunk.**
+  When the dispatch layer spawns a workstream sub-agent in an isolated worktree,
+  that sub-agent's work is based on the batch branch's current commit,
+  inheriting the planning foundation and every earlier-integrated workstream in
+  the same batch. The base advances as serial workstreams integrate.
+- **Trunk and batch integration HEAD are distinct refs.** The trunk is where a
+  finished batch lands; the batch integration HEAD is the in-flight commit a
+  batch's sub-agents extend. Basing children on the trunk discards in-batch
+  integration — the defect this section closes.
+
+### Why resolve rather than hardcode
+
+The contract serves adopters beyond symphonize's own repository
+(§req:modular-adoption), and those adopters do not all use `main`. Resolving the
+trunk from the repository's default branch — rather than introducing a
+configuration file — keeps the "no state beyond governance documents" constraint
+intact while removing the wrong-branch failure for every non-`main` project.
+
+### Why the worktree base needs explicit handling
+
+The agent worktree-isolation harness bases a new worktree on the repository's
+default branch, and the batch branch is already checked out in the parent
+worktree, so a child cannot check it out by name. symphonize cannot change the
+harness, so the protocol makes the base explicit: the dispatch layer passes the
+batch branch's commit to each sub-agent, which positions its worktree at that
+commit before working. Linked worktrees share one object store, so the commit
+resolves by SHA. The exact mechanism is an implementation detail; the contract
+is that children extend the batch integration HEAD.
+
+### Scope
+
+The hardcoded trunk spans conduct (`next.md`, `review.md`, `clean.md`,
+`protocols/batch-agent.md`) and compose (`triage.md`, `roadmap.md`), plus the
+`main`-relative descriptions in §spec:clean-supersession-safety and
+§spec:repo-state-reconciliation. The change is cross-plugin and touches the
+shared branching convention every agent inherits.


### PR DESCRIPTION
Triage of #167 (external adopter `point-source`/Kandev), classified as a **bug revealing a design gap** → SPEC + ROADMAP.

## The gap

symphonize hardcodes `main` as the integration branch across conduct (`next`, `review`, `clean`, `batch-agent`) and compose (`triage`, `roadmap`), plus two SPEC sections. Two failures:

1. A non-`main` trunk (e.g. `develop`) gets the wrong branch everywhere.
2. Worktree-isolated sub-agents fork from the repo default branch instead of the **batch branch HEAD**, so serial workstreams in a batch miss the planning foundation and each other's integrated work → cherry-pick conflicts and CI breakage. This breaks the vertical-slice model (`§spec:vertical-first-batch-selection`) **even on `main`-trunk projects** — that's the bug.

## What this PR adds

- **`§spec:integration-ref`** (Status: not started): the integration trunk is resolved once from the repository default branch (not hardcoded, not a new config file — preserves the no-extra-state constraint); worktree sub-agents descend from the batch integration HEAD, not the trunk. Includes the rationale and the harness constraint that forces the explicit-base mechanism (symphonize can't change `isolation: "worktree"`'s base, so the dispatch layer passes the batch SHA and the child positions its worktree there).
- **ROADMAP section** with two workstreams: `§road:resolve-trunk` and `§road:worktree-base-ref` (depends on the former), with a section-level `**Verify:**`.

Mechanism details (default-branch auto-detect; the exact reset-to-SHA step) are left to `/plan`/`/conduct:next`.

## Verification

markdownlint clean; new `##` headings carry suffix-placed slugs; no numbered headings; slug uniqueness holds; all `§`-references resolve; no deprecated modals. (Authored in the new heading-addressing grammar now enforced.)

Triage edits governance docs only — no release. The implementing PR will close #167 with `Fixes #167`. Next step: `/conduct:next` (or `/compose:plan` first to nail the auto-detect/reset mechanism).