### PR TITLE
feat: batch — integration-ref resolution (configurable trunk + worktree base)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,30 +38,3 @@ delegate-freshness contract in `plugins/notation/commands/init.md`.
 `plugins/notation/commands/init.md` and §spec:scaffold-freshness agree on
 the contract; governance-lint passes. The dependabot scaffolding lives with
 the `init` scaffolder, now in `plugins/notation/commands/init.md`.
-
-## Integration-ref resolution §road:integration-ref-resolution
-
-### Resolve the integration trunk across conduct and compose §road:resolve-trunk
-
-Replace hardcoded `main` with a trunk resolved from the repository default
-branch across `plugins/conduct/commands/{next,review,clean}.md`,
-`plugins/conduct/protocols/batch-agent.md`, and
-`plugins/compose/commands/{triage,roadmap}.md`, and update the `main`-relative
-wording in §spec:clean-supersession-safety and §spec:repo-state-reconciliation.
-§spec:integration-ref. Reported in #167.
-
-### Base worktree sub-agents on the batch integration HEAD §road:worktree-base-ref
-
-Make the dispatch and batch-agent protocol pass the batch branch commit to each
-worktree sub-agent and base its work there rather than the default branch
-(`plugins/conduct/commands/next.md`, `plugins/conduct/protocols/batch-agent.md`).
-§spec:integration-ref. Depends on §road:resolve-trunk. Reported in #167.
-
-**Verify:** in a scratch repo whose default branch is `develop`, run
-`/conduct:next` on a populated ROADMAP and confirm the batch branch is cut from
-`develop` and the PR targets `develop` (no reference to a non-existent `main`).
-In a batch of two serial workstreams touching the same file, confirm the second
-sub-agent's worktree already contains the first workstream's integrated commit
-(its work builds on it without a cherry-pick conflict) and CI passes after each
-integration. `grep -rn 'origin/main' plugins/` returns no hardcoded trunk in
-active command and protocol paths.

--- a/SPEC.md
+++ b/SPEC.md
@@ -490,16 +490,18 @@ deleted remote branch cannot be reopened.
 
 The clean command shall not close a PR or delete its remote branch
 based on title similarity, topic overlap, or heuristic matching.
-A PR is superseded only when every file it touches exists in main
-with equivalent changes. Verification procedure:
+A PR is superseded only when every file it touches exists in the
+integration trunk (the repository's resolved default branch,
+§spec:integration-ref) with equivalent changes. Verification
+procedure:
 
 1. For each open sub-agent PR, list unmerged commits
-   (`git log --oneline main..<branch>`).
+   (`git log --oneline <trunk>..<branch>`).
 2. For each unmerged commit, inspect the diff and confirm the
-   classes, functions, and files introduced exist in main.
-3. If any introduced symbol or file does not exist in main, the
+   classes, functions, and files introduced exist in the trunk.
+3. If any introduced symbol or file does not exist in the trunk, the
    PR is not superseded — leave it open.
-4. Only after all changes are confirmed present in main, close
+4. Only after all changes are confirmed present in the trunk, close
    the PR with a comment citing the merge commit or batch PR
    that landed the work.
 
@@ -1102,12 +1104,14 @@ context via `hookSpecificOutput.additionalContext`.
 
 - Before each user turn, the hook performs a **read-only** reconcile: a
   rate-limited `git fetch --prune`, then a comparison of the current branch
-  against its upstream and `origin/main`, and of the branch's pull request
+  against its upstream and the integration trunk (the repository's resolved
+  default branch, §spec:integration-ref), and of the branch's pull request
   against its remote state.
 - The hook injects context **only when reality diverges** from the naive
   "nothing changed since I last looked" assumption — the current branch's
-  PR is merged or closed; the branch is behind `origin/main`; the branch no
-  longer exists on the remote. When nothing diverges, it injects nothing.
+  PR is merged or closed; the branch is behind the resolved trunk; the
+  branch no longer exists on the remote. When nothing diverges, it injects
+  nothing.
 - The divergence is reported as a specific contradiction at the point of use
   (e.g. "PR #118 for this branch is MERGED"), not a status dump.
 - The hook never blocks the prompt and never mutates the working tree or the
@@ -1302,7 +1306,7 @@ is the placement and coverage change only. §req:modular-adoption
   identifier, deliberately allowed to differ — and avoidable with a short slug.
 
 ## Integration-ref resolution §spec:integration-ref
-*Status: not started*
+*Status: complete*
 
 symphonize's commands and the batch-agent protocol hardcode `main` as the
 integration branch: `git checkout -b … origin/main`, "verify main is current",

--- a/plugins/compose/commands/roadmap.md
+++ b/plugins/compose/commands/roadmap.md
@@ -98,8 +98,17 @@ Mozilla Open Science "Intro to Roadmapping."
 Before decomposing, assess the state of the spec. Apply
 backpressure proportional to the gap.
 
-1. Create a planning worktree. Fetch origin and start from tip of
-   main.
+1. Create a planning worktree. Fetch origin and start from the tip of
+   the integration trunk — the repository's own default branch (do
+   not hardcode `main`):
+
+   ```sh
+   trunk="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+   [ -z "$trunk" ] && trunk="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)"
+   [ -z "$trunk" ] && trunk=main
+   ```
+
+   For symphonize's own repository this resolves to `main`.
 2. Read REQUIREMENTS.md (if present), SPEC.md, and ROADMAP.md at
    the governance root. If operating on a package, also read root
    SPEC.md as upstream architectural context.

--- a/plugins/compose/commands/triage.md
+++ b/plugins/compose/commands/triage.md
@@ -156,15 +156,20 @@ proceeding.
 
 ## Phase 4: Commit and push
 
-1. Create a feature branch from `origin/main`. Triage edits
-   governance documents only and ships no behavior, so every
-   committing classification uses a `docs/` branch:
+1. Create a feature branch from the integration trunk. Resolve the
+   trunk from the repository's own default branch (do not hardcode
+   `main`); for symphonize's own repository it resolves to `main`.
+   Triage edits governance documents only and ships no behavior, so
+   every committing classification uses a `docs/` branch:
 
    - Bug → `docs/triage-N-slug`
    - Feature → `docs/triage-N-slug`
 
    ```bash
-   git checkout -b docs/triage-<issue-number>-<slug> origin/main
+   trunk="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+   [ -z "$trunk" ] && trunk="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)"
+   [ -z "$trunk" ] && trunk=main
+   git checkout -b "docs/triage-<issue-number>-<slug>" "origin/$trunk"
    ```
 
 2. Write the governance file updates.

--- a/plugins/conduct/commands/clean.md
+++ b/plugins/conduct/commands/clean.md
@@ -32,8 +32,20 @@ Do NOT update governance docs, run verification, or sync chezmoi.
 
 ## Full mode (post-merge cleanup)
 
-Run after PRs merge to main — either after a single batch or after
-reviewing all ralph-loop PRs.
+Run after PRs merge to the integration trunk — either after a single
+batch or after reviewing all ralph-loop PRs.
+
+Resolve the **trunk** — the branch finished work lands on — from the
+repository's own default branch; do not hardcode `main`:
+
+```sh
+trunk="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+[ -z "$trunk" ] && trunk="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)"
+[ -z "$trunk" ] && trunk=main
+```
+
+Use `$trunk` and `origin/$trunk` wherever the trunk is referenced
+below. For symphonize's own repository this resolves to `main`.
 
 Never run `git stash` under any circumstance. Stashes created by
 branch-switching during cleanup accumulate silently — the pop or
@@ -73,25 +85,25 @@ Do not stash, force-checkout, or silently discard uncommitted work.
 - Close open sub-agent PRs only after diff-level supersession
   verification. Do not close based on title similarity or topic
   overlap. For each open sub-agent PR (`gh pr list --author @me`):
-  1. List unmerged commits (`git log --oneline main..<branch>`).
+  1. List unmerged commits (`git log --oneline "$trunk..<branch>"`).
   2. For each unmerged commit, inspect the diff and confirm the
-     classes, functions, and files introduced exist in main.
-  3. If any introduced symbol or file does not exist in main, the
-     PR is not superseded — leave it open.
-  4. Only after all changes are confirmed present in main, close
+     classes, functions, and files introduced exist in `$trunk`.
+  3. If any introduced symbol or file does not exist in `$trunk`,
+     the PR is not superseded — leave it open.
+  4. Only after all changes are confirmed present in `$trunk`, close
      the PR with a comment citing the merge commit or batch PR
      that landed the work.
 
-### 2. Checkout main and fast-forward
+### 2. Check out the trunk and fast-forward
 
-Switch to `main` and pull:
+Switch to `$trunk` and pull:
 
 ```sh
-git checkout main
+git checkout "$trunk"
 git pull --ff-only
 ```
 
-If fast-forward fails, warn and abort — main has diverged and
+If fast-forward fails, warn and abort — the trunk has diverged and
 needs manual resolution.
 
 Re-run the dirty-state guard (step 0 logic) after checkout. Lock
@@ -130,11 +142,11 @@ recent commit history (`git log --oneline -20`). Check:
 - Run `/notation:lint` and fix any violations before committing.
 
 Commit governance doc changes to a `docs/post-merge-cleanup` branch
-and open a PR (or push directly to main if the project allows).
+and open a PR (or push directly to the trunk if the project allows).
 
 ### 5. Verify
 
-Run verification against main — not a branch. The quality gate is
+Run verification against the trunk — not a branch. The quality gate is
 zero failures and zero warnings — the only sustainable baseline. A
 "pre-existing" failure is not an excuse: every known failure that
 ships becomes invisible within a session, and within two batches the
@@ -142,4 +154,4 @@ failure count drifts so real regressions hide behind the noise floor.
 
 - Run the project's analysis tool — zero warnings.
 - Run the project's test suite — zero failures.
-- `git log --oneline -5` — confirm HEAD is clean main.
+- `git log --oneline -5` — confirm HEAD is the clean trunk.

--- a/plugins/conduct/commands/next.md
+++ b/plugins/conduct/commands/next.md
@@ -30,10 +30,24 @@ Ensure local state is current before selecting work.
 3. Remove any leftover worktrees from `.claude/worktrees/` and their
    backing git worktrees (`git worktree list`, `git worktree remove`
    for any linked worktrees that are no longer needed).
-4. Read ROADMAP.md from `origin/main` at the governance root path
-   (use `git show origin/main:<governance-root-relative>/ROADMAP.md`)
+4. Resolve the integration **trunk** — the branch a finished batch
+   lands on — from the repository's own default branch; do not
+   hardcode `main`. Read the remote's recorded default branch, falling
+   back to `gh`, then to `main`:
+
+   ```sh
+   trunk="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+   [ -z "$trunk" ] && trunk="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)"
+   [ -z "$trunk" ] && trunk=main
+   ```
+
+   Use `$trunk` and `origin/$trunk` wherever a trunk branch is
+   referenced below, and pass `$trunk` to the batch agent. For
+   symphonize's own repository this resolves to `main`.
+5. Read ROADMAP.md from `origin/$trunk` at the governance root path
+   (`git show "origin/$trunk:<governance-root-relative>/ROADMAP.md"`)
    — not the local working copy, which may be stale. For the repo
-   root governance, this is `git show origin/main:ROADMAP.md`.
+   root governance, this is `git show "origin/$trunk:ROADMAP.md"`.
 
 ## 2. Detect unattended mode
 
@@ -49,7 +63,7 @@ to cross-check.
 ## 3. Select workstream target (chain-preferring)
 
 If `$1` is provided, use it. Otherwise, using the ROADMAP.md content
-from step 1.4, select workstreams by building dependency chains that
+from step 1.5, select workstreams by building dependency chains that
 reach the user-facing surface. §spec:vertical-first-batch-selection
 
 ### 3.1 Identify the active section
@@ -160,6 +174,9 @@ Spawn a single Agent with `isolation: "worktree"` and pass it:
 - The full contents of the batch agent protocol you just read
 - The conduct plugin root: `${CLAUDE_PLUGIN_ROOT}` (so the
   batch agent can read `protocols/batch-agent.md`)
+- The resolved integration trunk `$trunk` (step 1.4) — the branch
+  the batch lands on; the agent cuts its branch from `origin/$trunk`
+  and targets the PR there
 - The workstream target(s) selected in step 3
 - If `unattended`: the flag `--unattended`
 - Instruction: "Follow the orchestrator protocol to implement this

--- a/plugins/conduct/commands/review.md
+++ b/plugins/conduct/commands/review.md
@@ -8,8 +8,9 @@ description: Integrate a PR — resolve conflicts and check out the branch local
 `/review` is the integration/merge half of PR review: it answers
 "are we building it right" at the mechanical level — getting a PR
 from `/next` or `/orchestrate` into a state where it can land. It
-resolves conflicts with main, rebases, and checks out the branch
-locally so the user (or the taste half of review) can exercise it.
+resolves conflicts with the integration trunk, rebases, and checks
+out the branch locally so the user (or the taste half of review) can
+exercise it.
 
 The correctness/taste half — summarizing changes against the spec
 and guiding verification against the roadmap `**Verify:**` criteria —
@@ -30,10 +31,19 @@ the compose half to judge whether the change is correct.
    URL). Otherwise, list open PRs (`gh pr list --state open
    --author @me`) and ask the user which one to review.
 
-2. **Resolve conflicts.** Check if the PR has merge conflicts
-   with main. If so, check out the branch, rebase onto
-   `origin/main`, resolve conflicts, and force-push. Warn the
-   user before force-pushing.
+2. **Resolve conflicts.** Resolve the integration trunk from the
+   repository's own default branch (do not hardcode `main`):
+
+   ```sh
+   trunk="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+   [ -z "$trunk" ] && trunk="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)"
+   [ -z "$trunk" ] && trunk=main
+   ```
+
+   Check if the PR has merge conflicts with `origin/$trunk`. If so,
+   check out the branch, rebase onto `origin/$trunk`, resolve
+   conflicts, and force-push. Warn the user before force-pushing.
+   For symphonize's own repository the trunk resolves to `main`.
 
 3. **Check out locally.** Switch to the PR branch so the user
    can run the application and test.

--- a/plugins/conduct/hooks/reconcile-repo-state.sh
+++ b/plugins/conduct/hooks/reconcile-repo-state.sh
@@ -5,7 +5,10 @@
 # Before each turn, reconcile the agent's view of the repo with the remote and
 # inject context ONLY when reality diverges from the naive "nothing changed
 # since I last looked" assumption: the current branch's PR is merged/closed,
-# the branch is behind origin/main, or the branch is gone from the remote.
+# the branch is behind the integration trunk, or the branch is gone from the
+# remote. The trunk is the repository's own default branch (not hardcoded
+# main), so the comparison is correct for projects whose trunk is not main
+# (SPEC §spec:integration-ref).
 #
 # Contract (see SPEC.md §spec:repo-state-reconciliation):
 #   - Read-only. Performs at most a rate-limited `git fetch`; never checks out,
@@ -109,7 +112,7 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
   fi
 fi
 
-# 2/3. Branch position relative to its upstream and to origin/main, using
+# 2/3. Branch position relative to its upstream and to the integration trunk,
 #      local remote-tracking refs (no network — works without gh).
 upstream="$(git -C "$cwd" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
 if [ -n "$upstream" ]; then
@@ -119,15 +122,19 @@ if [ -n "$upstream" ]; then
   fi
 fi
 
-# Behind origin/main: commits on origin/main not reachable from HEAD. Only
-# meaningful when origin/main exists and is not the current branch itself.
-if git -C "$cwd" rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+# Behind the integration trunk: commits on the trunk not reachable from HEAD.
+# The trunk is the repository's default branch (no network — read the
+# remote-tracking HEAD ref), falling back to main. Only meaningful when the
+# trunk ref exists and is not the current branch itself.
+trunk="$(git -C "$cwd" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+[ -z "$trunk" ] && trunk=main
+if git -C "$cwd" rev-parse --verify --quiet "origin/$trunk" >/dev/null 2>&1; then
   head_sha="$(git -C "$cwd" rev-parse HEAD 2>/dev/null || true)"
-  main_sha="$(git -C "$cwd" rev-parse origin/main 2>/dev/null || true)"
-  if [ -n "$head_sha" ] && [ "$head_sha" != "$main_sha" ]; then
-    behind="$(git -C "$cwd" rev-list --count "HEAD..origin/main" 2>/dev/null || echo 0)"
+  trunk_sha="$(git -C "$cwd" rev-parse "origin/$trunk" 2>/dev/null || true)"
+  if [ -n "$head_sha" ] && [ "$head_sha" != "$trunk_sha" ]; then
+    behind="$(git -C "$cwd" rev-list --count "HEAD..origin/$trunk" 2>/dev/null || echo 0)"
     if [ "${behind:-0}" -gt 0 ]; then
-      messages+=("This branch is ${behind} commit(s) behind \`origin/main\`. Its base is stale; rebase or merge \`origin/main\` before relying on it being current.")
+      messages+=("This branch is ${behind} commit(s) behind \`origin/${trunk}\`. Its base is stale; rebase or merge \`origin/${trunk}\` before relying on it being current.")
     fi
   fi
 fi

--- a/plugins/conduct/hooks/reconcile-repo-state.test.sh
+++ b/plugins/conduct/hooks/reconcile-repo-state.test.sh
@@ -327,6 +327,42 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 10: trunk resolved from default branch (develop) -> reports behind develop
+# ---------------------------------------------------------------------------
+# A repo whose default branch is `develop`, not `main`. The hook must compare
+# HEAD against origin/develop (resolved from origin/HEAD), not a non-existent
+# origin/main. Regression for §spec:integration-ref.
+STAMP_DIR="$ROOT/stamps10"
+remote10="$ROOT/develop-remote.git"
+work10="$ROOT/develop"
+tgit init --quiet --bare "$remote10"
+# Make `develop` the remote's default branch (HEAD).
+tgit -C "$remote10" symbolic-ref HEAD refs/heads/develop
+tgit init --quiet "$work10"
+tgit -C "$work10" checkout -q -b develop
+echo "seed" >"$work10/file"
+tgit -C "$work10" add file
+tgit -C "$work10" commit --quiet -m "seed"
+tgit -C "$work10" remote add origin "$remote10"
+tgit -C "$work10" push --quiet -u origin develop
+# Record origin/HEAD locally so the hook can resolve the default branch.
+tgit -C "$work10" remote set-head origin develop
+# Advance origin/develop from a clone, then move the local feature branch behind it.
+clone10="$ROOT/develop-clone"
+tgit clone --quiet "$remote10" "$clone10"
+echo "more" >"$clone10/file2"
+tgit -C "$clone10" add file2
+tgit -C "$clone10" commit --quiet -m "advance develop"
+tgit -C "$clone10" push --quiet origin develop
+tgit -C "$work10" checkout -q -b feature-x
+tgit -C "$work10" fetch --quiet origin
+ghdir="$ROOT/gh-none10"
+make_gh_stub "$ghdir" NONE
+out="$(RECONCILE_FETCH_DISABLE=1 run_hook "$work10" "$ghdir")"
+assert_contains "behind report names resolved trunk origin/develop" "$out" "origin/develop"
+assert_not_contains "behind report does not name origin/main" "$out" "origin/main"
+
+# ---------------------------------------------------------------------------
 echo
 echo "passed: $pass  failed: $fail"
 [ "$fail" -eq 0 ]

--- a/plugins/conduct/protocols/batch-agent.md
+++ b/plugins/conduct/protocols/batch-agent.md
@@ -66,7 +66,20 @@ does not mean unchecked.
 
 ## Phase 2: Setup
 
-1. Fetch origin and verify main is current.
+1. Fetch origin and resolve the integration **trunk** — the branch a
+   finished batch lands on. The dispatch layer passes `$trunk`; if it
+   did not, resolve it from the repository's own default branch (do
+   not hardcode `main`):
+
+   ```sh
+   trunk="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+   [ -z "$trunk" ] && trunk="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)"
+   [ -z "$trunk" ] && trunk=main
+   ```
+
+   Verify `origin/$trunk` is current. Use `$trunk` and `origin/$trunk`
+   everywhere a trunk branch is referenced below. For symphonize's own
+   repository this resolves to `main`.
 2. Verify you are in a worktree (not the user's main checkout).
    Confirm with: `git worktree list` — your working directory
    should appear as a linked worktree, not the main working tree.
@@ -159,7 +172,7 @@ After Phase 5 verification passes and before `/security-review`.
 Implements §spec:simplify-gate.
 
 1. **Skip-condition check.** Compute the changed-file list with
-   `git diff --name-only $(git merge-base HEAD origin/main) HEAD`.
+   `git diff --name-only "$(git merge-base HEAD "origin/$trunk")" HEAD`.
    If every changed path is a non-source file (markdown, YAML, or
    governance documents — SPEC.md, ROADMAP.md, REQUIREMENTS.md,
    CHANGELOG.md), skip the gate and record the skip in the batch
@@ -255,10 +268,11 @@ After Phase 5a completes (or is skipped) and before pushing:
 
 The batch agent owns the git work for the slice:
 
-- Work on a feature branch — never commit to main. One logical unit
-  of work per branch (the batch). Branch naming
+- Work on a feature branch — never commit to the trunk. One logical
+  unit of work per branch (the batch). Branch naming
   `<type>/<short-description>` matches the commit scope (e.g.
-  `feat/buffer-aware-execution`). Create from `origin/main`.
+  `feat/buffer-aware-execution`). Create from `origin/$trunk` (the
+  resolved trunk, Phase 2).
 - One logical change per commit. If a commit message needs "and,"
   split it into two commits. Use conventional commits:
   `<type>(<scope>): <description>`, where type is one of

--- a/plugins/conduct/protocols/batch-agent.md
+++ b/plugins/conduct/protocols/batch-agent.md
@@ -101,8 +101,23 @@ does not mean unchecked.
 - Parallel dispatch (multiple Agent calls in one message) for
   workstreams with no file overlap. Serial for workstreams that
   touch shared files or depend on earlier results.
+- **Base each sub-agent on the batch integration HEAD, not the
+  trunk.** The worktree-isolation harness cuts a new worktree from
+  the repository's default branch, and the batch branch is already
+  checked out in this (parent) worktree, so a child cannot check it
+  out by name. Immediately before spawning a sub-agent, capture the
+  batch branch's current commit (`base_sha="$(git rev-parse HEAD)"`)
+  and pass that SHA to the sub-agent. Instruct it to position its
+  worktree there as its **first action**, before any work:
+  `git reset --hard <base_sha>`. Linked worktrees share one object
+  store, so the SHA is reachable even though the branch name is not.
+  This makes the child inherit the planning foundation and every
+  earlier-integrated workstream. For **serial** workstreams,
+  re-capture `base_sha` after each cherry-pick (Phase 4) so the next
+  child descends from the just-integrated commit — never from the
+  bare trunk.
 - Each sub-agent receives: the workstream slug, its ROADMAP.md
-  description, and the project rules.
+  description, the base commit SHA (above), and the project rules.
 - Sub-agents follow the project's standard workflow (test-first
   for code tasks, verify for operational tasks).
 


### PR DESCRIPTION
Implements `§spec:integration-ref` (#167). Closes the hardcoded-`main` design gap for non-`main`-trunk adopters and the worktree-fork-from-trunk defect that breaks vertical-slice batch execution.

Fixes #167

## Workstreams (one commit each)

- **§road:resolve-trunk** — `feat(conduct,compose): resolve integration trunk from default branch`. Replaces hardcoded `main`/`origin/main` with a trunk resolved from the repo's default branch (`git symbolic-ref refs/remotes/origin/HEAD` → `gh repo view --json defaultBranchRef` → `main` fallback) across conduct (`next`, `review`, `clean`, `batch-agent`) and compose (`triage`, `roadmap`); generalizes the `reconcile-repo-state.sh` hook the same way; updates the `main`-relative wording in `§spec:clean-supersession-safety` and `§spec:repo-state-reconciliation`. No new config file — auto-detect keeps the no-extra-state constraint.
- **§road:worktree-base-ref** — `feat(conduct): base worktree sub-agents on batch integration HEAD`. Dispatch (`next.md`) and the batch-agent protocol now pass the batch branch HEAD SHA to each worktree sub-agent, which bases its worktree on that commit before working — so serial workstreams inherit earlier-integrated work instead of re-forking from trunk.

## Verification

- **Hook test 18/18 pass**, including new regression tests proving the resolved-trunk behavior on a `develop`-default repo (`behind report names origin/develop` / `does not name origin/main`) — the develop-trunk case from the Verify block, actually exercised.
- `grep` finds no hardcoded trunk left in active command/protocol/hook paths (remaining `origin/main` hits are intentional test fixtures covering the main-default case).
- markdownlint clean; slug uniqueness holds; all `§`-references resolve; `§spec:integration-ref` → complete; ROADMAP section removed.
- Honest scope note: the worktree-base **dispatch** behavior is harness-dependent (`isolation: "worktree"` bases off the default branch), so the fix is protocol text instructing the reset-to-SHA base step; that path is verified by reasoning + the protocol wording, not an end-to-end harness run. The trunk-resolution path *is* test-covered via the hook.

Phase 5a `/simplify` skipped (diff is governance docs + command/protocol markdown + one shell hook & its test). `/security-review`: no findings (resolved `$trunk` is git-controlled metadata, consistently quoted; hook stays read-only).

> Run /review --comment to post code-quality findings as PR comments.