### PR TITLE
docs(spec): triage #132 — batch delivery robustness

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,12 +43,13 @@ the `init` scaffolder, now in `plugins/notation/commands/init.md`.
 
 ### Harden Phase 6 delivery and add dispatch recovery §road:harden-batch-delivery
 
-Make Phase 6 a hard completion gate and add a dispatch-layer recovery path in
-`plugins/conduct/protocols/batch-agent.md` and `plugins/conduct/commands/next.md`
-— a batch agent does not return without a pushed conventional branch, an opened
-PR, and the shipped workstream removed from ROADMAP.md; when it does, `/conduct:next`
-adopts the worktree and finishes delivery itself; document that `SendMessage`
-resume is not assumable. §spec:batch-delivery. Reported in #132.
+Harden batch delivery in `plugins/conduct/protocols/batch-agent.md` and
+`plugins/conduct/commands/next.md`: keep the quality gates from ending the
+agent's turn before Phase 6, make Phase 6 a hard completion gate (no return
+without a pushed conventional branch, an opened PR, and the shipped workstream
+removed from ROADMAP.md), and add a dispatch-layer recovery path that adopts the
+worktree and finishes delivery when an agent returns without a PR; document that
+`SendMessage` resume is not assumable. §spec:batch-delivery. Reported in #132.
 
 **Verify:** `plugins/conduct/protocols/batch-agent.md` states Phase 6 as a hard
 gate (no return without a PR URL) and notes `SendMessage` resume is not

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,3 +38,25 @@ delegate-freshness contract in `plugins/notation/commands/init.md`.
 `plugins/notation/commands/init.md` and §spec:scaffold-freshness agree on
 the contract; governance-lint passes. The dependabot scaffolding lives with
 the `init` scaffolder, now in `plugins/notation/commands/init.md`.
+
+## Batch delivery robustness §road:batch-delivery-robustness
+
+### Harden Phase 6 delivery and add dispatch recovery §road:harden-batch-delivery
+
+Make Phase 6 a hard completion gate and add a dispatch-layer recovery path in
+`plugins/conduct/protocols/batch-agent.md` and `plugins/conduct/commands/next.md`
+— a batch agent does not return without a pushed conventional branch, an opened
+PR, and the shipped workstream removed from ROADMAP.md; when it does, `/conduct:next`
+adopts the worktree and finishes delivery itself; document that `SendMessage`
+resume is not assumable. §spec:batch-delivery. Reported in #132.
+
+**Verify:** `plugins/conduct/protocols/batch-agent.md` states Phase 6 as a hard
+gate (no return without a PR URL) and notes `SendMessage` resume is not
+assumable; `plugins/conduct/commands/next.md` has a "Recovery — incomplete
+delivery" path that adopts the worktree, removes the shipped ROADMAP workstream,
+re-runs CI, pushes to a `<type>/<scope>-<slug>` branch, and opens the PR.
+Exercise it: dispatch a batch; if the agent returns a PR URL, delivery worked
+end-to-end; if it returns without one, confirm `/conduct:next` detects the
+missing URL and delivers from the worktree (conventional branch, ROADMAP bullet
+gone, PR open, CI green) — the manual workaround used for #165 and #171 becomes
+the documented path.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1370,14 +1370,26 @@ shared branching convention every agent inherits.
 ## Batch delivery §spec:batch-delivery
 *Status: not started*
 
-A batch agent dispatched by `/conduct:next` (an `Agent` worktree) sometimes
-completes the work — implementing the workstream, passing the Phase 5 gates,
-committing in its worktree — yet returns without pushing a branch or opening a
-PR, and without removing the shipped workstream from ROADMAP.md. The dispatch
-layer is then left with no PR to track, a ROADMAP that still lists shipped work,
-and no reliable way to nudge the stalled sub-agent to finish. The premise that
-every batch yields a reviewable PR (§req:success-criteria) breaks silently — the
-loop proceeds as though delivery happened.
+A batch agent dispatched by `/conduct:next` (an `Agent` worktree) implements its
+workstream and commits in its worktree, then — while running its mandatory
+quality gates — stops without pushing a branch, opening a PR, or removing the
+shipped workstream from ROADMAP.md. The dispatch layer is then left with no PR to
+track, a ROADMAP that still lists shipped work, and no reliable way to nudge the
+stalled sub-agent to finish. The premise that every batch yields a reviewable PR
+(§req:success-criteria) breaks silently — the loop proceeds as though delivery
+happened.
+
+### Why agents stall before delivery
+
+The batch agent's mandatory gates (`/security-review`, `/simplify`) are Skills.
+Invoking a Skill inside a sub-agent injects a self-contained task prompt; the
+agent answers that prompt and ends its turn. In the main session the session
+loop drives the next turn, so control returns after a Skill — but a sub-agent
+has no such driver, so it stops, and every protocol phase sequenced after a Skill
+invocation is unreachable. Observed twice: each agent committed its work, invoked
+`/security-review`, emitted the review, and ended its turn — Phase 6 never ran.
+The corrected behavior is that the quality gates do not cost the agent its turn
+before delivery; the mechanism that achieves it is an implementation choice.
 
 ### Observable behavior
 
@@ -1395,7 +1407,7 @@ loop proceeds as though delivery happened.
   `<type>/<scope>-<slug>`, never the `worktree-agent-<id>` name the isolation
   harness assigns to the sub-agent's worktree.
 
-### Why the dispatch layer recovers rather than resumes
+### Why recovery, not resume
 
 In-band resumption of a stalled sub-agent is not assumable. `SendMessage`-based
 resume is gated behind Claude Code's `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`,
@@ -1416,6 +1428,7 @@ failure, never a silent no-op. §req:success-criteria
 
 ### Scope
 
-The contract spans `plugins/conduct/protocols/batch-agent.md` (Phase 5 step 6
-and Phase 6) and the dispatch layer `plugins/conduct/commands/next.md`
-(recovery). Reported by the maintainer after the failure recurred across batches.
+The contract spans `plugins/conduct/protocols/batch-agent.md` (the quality gates,
+Phase 5 step 6, and Phase 6) and the dispatch layer
+`plugins/conduct/commands/next.md` (recovery). Reported by the maintainer (#132)
+and corroborated by two stalls observed in practice.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1366,3 +1366,56 @@ The hardcoded trunk spans conduct (`next.md`, `review.md`, `clean.md`,
 `main`-relative descriptions in §spec:clean-supersession-safety and
 §spec:repo-state-reconciliation. The change is cross-plugin and touches the
 shared branching convention every agent inherits.
+
+## Batch delivery §spec:batch-delivery
+*Status: not started*
+
+A batch agent dispatched by `/conduct:next` (an `Agent` worktree) sometimes
+completes the work — implementing the workstream, passing the Phase 5 gates,
+committing in its worktree — yet returns without pushing a branch or opening a
+PR, and without removing the shipped workstream from ROADMAP.md. The dispatch
+layer is then left with no PR to track, a ROADMAP that still lists shipped work,
+and no reliable way to nudge the stalled sub-agent to finish. The premise that
+every batch yields a reviewable PR (§req:success-criteria) breaks silently — the
+loop proceeds as though delivery happened.
+
+### Observable behavior
+
+- **Delivery is a hard completion gate.** A batch agent does not report success
+  until it has pushed its branch and opened a PR; a return without a PR URL is a
+  failure, not a partial success. Removing the shipped workstream from
+  ROADMAP.md is part of the same gate.
+- **The dispatch layer owns recovery.** When a batch agent returns without a PR
+  URL, `/conduct:next` adopts the worktree's committed work and finishes
+  delivery itself — remove the shipped ROADMAP workstream, re-run CI, push to a
+  conventional branch, open the PR — rather than resuming the sub-agent. The
+  worktree's commits are the source of truth; delivery completes deterministically
+  from them.
+- **Delivered branches use the conventional name.** A delivered branch follows
+  `<type>/<scope>-<slug>`, never the `worktree-agent-<id>` name the isolation
+  harness assigns to the sub-agent's worktree.
+
+### Why the dispatch layer recovers rather than resumes
+
+In-band resumption of a stalled sub-agent is not assumable. `SendMessage`-based
+resume is gated behind Claude Code's `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`,
+which is off by default and — because the gate is read at module init — takes
+effect only through a shell-level environment export before launch, not through
+`settings.json`. It is also version-dependent. So in the common configuration
+there is no way to drive a stalled batch agent to completion. Recovery from the
+worktree is harness-independent: the commits already exist, and the dispatch
+layer finishes delivery from them without depending on any resume mechanism.
+
+### Why delivery is a hard gate
+
+A partial success that reads as completion is the worst failure mode — the loop
+advances believing a PR exists, the ROADMAP keeps listing shipped work, and the
+gap surfaces only on a later manual check. A hard gate paired with dispatch-layer
+recovery guarantees every attempted batch ends in a reviewable PR or an explicit
+failure, never a silent no-op. §req:success-criteria
+
+### Scope
+
+The contract spans `plugins/conduct/protocols/batch-agent.md` (Phase 5 step 6
+and Phase 6) and the dispatch layer `plugins/conduct/commands/next.md`
+(recovery). Reported by the maintainer after the failure recurred across batches.


### PR DESCRIPTION
Triage of #132 (maintainer-authored), classified as a **bug revealing a design gap** → SPEC + ROADMAP.

## The gap

Batch agents dispatched by `/conduct:next` sometimes complete the work and commit in their worktree but **return before Phase 6** — no branch pushed, no PR, and the shipped workstream left in ROADMAP.md. The dispatch layer can't reliably resume them: `SendMessage` resume is gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` (off by default, read at module init so it needs a shell export — not `settings.json` — and is version-dependent). So the "every batch yields a reviewable PR" premise (`§req:success-criteria`) breaks silently.

**Directly corroborated this session:** PRs #165 and #171 both stalled exactly this way and required the dispatch layer to finish delivery manually from the worktree.

## What this PR adds

- **`§spec:batch-delivery`** (Status: not started): delivery is a **hard completion gate** (no return without a PR URL; ROADMAP removal is part of the gate); the **dispatch layer owns recovery** (adopt the worktree, remove the ROADMAP bullet, re-run CI, push a conventional branch, open the PR) rather than resuming the sub-agent; delivered branches use `<type>/<scope>-<slug>`, not `worktree-agent-<id>`. Records *why* `SendMessage` resume is a **rejected dependency** (the module-init env gate) so it isn't reintroduced.
- **ROADMAP** `§road:harden-batch-delivery` under a new section, with a section-level `**Verify:**`.

Implementation (the exact Phase 6 hard-gate wording in `protocols/batch-agent.md` and the "Recovery — incomplete delivery" path in `commands/next.md`) is left to `/conduct:next`.

## Note on a related issue

#132 references an earlier branch-naming issue (agents pushing the `worktree-agent-<id>` name verbatim). I folded conventional-branch-naming into the delivery contract here since it's intrinsic to clean delivery and #132 couples them — if that separate issue is still open, it converges on this same protocol fix.

## Verification

markdownlint clean; new `##` headings carry suffix slugs; no numbered headings; slug uniqueness holds; all references resolve; no deprecated modals (in Vale-scoped docs).

Triage edits governance docs only — no release. The implementing PR closes #132 with `Fixes #132`. Next: `/conduct:next`.