### PR TITLE
feat: batch — harden batch delivery (#132)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,25 +39,3 @@ delegate-freshness contract in `plugins/notation/commands/init.md`.
 the contract; governance-lint passes. The dependabot scaffolding lives with
 the `init` scaffolder, now in `plugins/notation/commands/init.md`.
 
-## Batch delivery robustness §road:batch-delivery-robustness
-
-### Harden Phase 6 delivery and add dispatch recovery §road:harden-batch-delivery
-
-Harden batch delivery in `plugins/conduct/protocols/batch-agent.md` and
-`plugins/conduct/commands/next.md`: keep the quality gates from ending the
-agent's turn before Phase 6, make Phase 6 a hard completion gate (no return
-without a pushed conventional branch, an opened PR, and the shipped workstream
-removed from ROADMAP.md), and add a dispatch-layer recovery path that adopts the
-worktree and finishes delivery when an agent returns without a PR; document that
-`SendMessage` resume is not assumable. §spec:batch-delivery. Reported in #132.
-
-**Verify:** `plugins/conduct/protocols/batch-agent.md` states Phase 6 as a hard
-gate (no return without a PR URL) and notes `SendMessage` resume is not
-assumable; `plugins/conduct/commands/next.md` has a "Recovery — incomplete
-delivery" path that adopts the worktree, removes the shipped ROADMAP workstream,
-re-runs CI, pushes to a `<type>/<scope>-<slug>` branch, and opens the PR.
-Exercise it: dispatch a batch; if the agent returns a PR URL, delivery worked
-end-to-end; if it returns without one, confirm `/conduct:next` detects the
-missing URL and delivers from the worktree (conventional branch, ROADMAP bullet
-gone, PR open, CI green) — the manual workaround used for #165 and #171 becomes
-the documented path.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1368,7 +1368,7 @@ The hardcoded trunk spans conduct (`next.md`, `review.md`, `clean.md`,
 shared branching convention every agent inherits.
 
 ## Batch delivery §spec:batch-delivery
-*Status: not started*
+*Status: complete*
 
 A batch agent dispatched by `/conduct:next` (an `Agent` worktree) implements its
 workstream and commits in its worktree, then — while running its mandatory

--- a/plugins/conduct/commands/next.md
+++ b/plugins/conduct/commands/next.md
@@ -191,11 +191,54 @@ Spawn a single Agent with `isolation: "worktree"` and pass it:
 
 Wait for the agent to complete.
 
-## 5. Record progress
+## 5. Recovery — incomplete delivery
 
-If the agent returned a PR URL:
+Delivery is a hard gate for the batch agent (`protocols/batch-agent.md`
+Phase 6): a return without a PR URL is a failure, not a partial success.
+When the agent returns **without a PR URL**, the dispatch layer adopts
+the agent's committed worktree and finishes delivery itself rather than
+resuming the sub-agent. In-band resume is not assumable — `SendMessage`
+resume is gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` (off by
+default, read at module init so it needs a shell export, version-
+dependent) — so recovery works from the durable commits the agent left
+behind. §spec:batch-delivery
+
+If the agent's result contains no PR URL:
+
+1. **Locate the worktree.** Find the agent's worktree under
+   `.claude/worktrees/` (`git worktree list`); its branch is the
+   harness-assigned `worktree-agent-<id>`. Its commits are the source of
+   truth.
+2. **Verify there is work to deliver.** Confirm the worktree has commits
+   ahead of `origin/$trunk`
+   (`git -C <worktree> log --oneline "origin/$trunk..HEAD"`). If it has
+   none, there is nothing to recover — report the failure to the user
+   and stop; do not open an empty PR.
+3. **Remove the shipped ROADMAP workstream(s)** for this batch from
+   ROADMAP.md in the worktree, if the agent did not already
+   (Phase 5 step 6), and commit that change.
+4. **Re-run CI** (the command from `.github/workflows/ci.yml`) in the
+   worktree. Do not push until it passes; fix or report blockers.
+5. **Push to a conventional branch.** Create `<type>/<scope>-<slug>`
+   from the worktree HEAD (never push the `worktree-agent-<id>` name)
+   and push it to origin.
+6. **Open the PR.** Single PR targeting `$trunk`, body listing each
+   shipped workstream and including:
+
+   ```text
+   > Run /review --comment to post code-quality findings as PR comments.
+   ```
+
+7. Treat the resulting PR URL as the batch result for step 6 below.
+
+## 6. Record progress
+
+If a PR URL exists (returned by the agent, or produced by recovery in
+step 5):
 - Append a line to `.symphonize-progress.local.md` at the governance
   root: `- <workstream-slug>: <PR-URL>`
 - Create the file if it doesn't exist.
 
-Relay the agent's result (PR URL, errors, or status) to the user.
+Relay the result (PR URL, errors, or status) to the user. If recovery
+ran, note that the batch agent stalled before delivery and the dispatch
+layer completed it from the worktree.

--- a/plugins/conduct/protocols/batch-agent.md
+++ b/plugins/conduct/protocols/batch-agent.md
@@ -181,9 +181,32 @@ When all workstreams are merged:
    thumb — if the design intent survives, cut it; if the *why*
    disappears, keep it.
 
+## Quality gates run as sub-agents, never as Skills
+
+Phases 5a and 5b are mandatory quality gates, but the batch agent
+**must not invoke `/simplify` or `/security-review` as Skills.** A Skill
+invoked inside a sub-agent injects a self-contained task prompt; the
+agent answers it and **ends its turn**. The main session has a session
+loop that drives the next turn, so control returns after a Skill — but a
+batch agent is itself a sub-agent with no such driver, so it stops, and
+every protocol phase sequenced after the Skill (including Phase 6
+delivery) becomes unreachable. This stall was observed twice in practice
+(#165, #171): each agent committed its work, ran the gate as a Skill,
+emitted the result, and ended its turn — Phase 6 never ran.
+§spec:batch-delivery (skill-ends-sub-agent-turn).
+
+Therefore each gate runs as an **`Agent` sub-agent** (`isolation:
+"worktree"`), not as a Skill. A sub-agent's result returns to the batch
+agent as a tool result, so control comes back and the protocol
+continues. Instruct the reviewer sub-agent to perform the corresponding
+review over the batch diff and **report findings as its final message**;
+the batch agent then acts on those findings in its own turn. The
+batch agent does not invoke the `/simplify` or `/security-review` Skills
+directly under any circumstance.
+
 ## Phase 5a: Simplify Gate (mandatory)
 
-After Phase 5 verification passes and before `/security-review`.
+After Phase 5 verification passes and before Phase 5b.
 Implements §spec:simplify-gate.
 
 1. **Skip-condition check.** Compute the changed-file list with
@@ -193,33 +216,54 @@ Implements §spec:simplify-gate.
    CHANGELOG.md), skip the gate and record the skip in the batch
    agent's status report so the reviewer knows why Phase 5a did not
    execute. Proceed directly to Phase 5b.
-2. **Single `/simplify` invocation.** Run `/simplify` exactly once
-   over the batch diff. Do not loop until clean — `/simplify` is an
-   actuator, and iteration risks re-refactoring its own output.
-3. **Fix review with revert-on-conflict.** After `/simplify` applies
-   fixes, inspect the resulting diff. If any fix contradicts a
-   deliberate design choice made during implementation (intentional
-   inlining, deliberate duplication for independence, readability
-   over DRY), revert that fix in a separate commit whose message
-   explains the reversion.
+2. **Single simplify sub-agent.** Spawn one `Agent` sub-agent to run a
+   simplify pass over the batch diff and report its suggested fixes as
+   its final message. Run it exactly once — simplify is an actuator, and
+   iteration risks re-refactoring its own output. Do **not** invoke the
+   `/simplify` Skill (it would end this agent's turn before Phase 6).
+3. **Fix review with revert-on-conflict.** The batch agent applies the
+   reviewer's fixes in its own turn, then inspects the diff. If any fix
+   contradicts a deliberate design choice made during implementation
+   (intentional inlining, deliberate duplication for independence,
+   readability over DRY), revert that fix in a separate commit whose
+   message explains the reversion.
 4. **Mandatory CI re-run.** Run the CI command discovered in Phase 2
    after fixes (and any reversions) settle. Simplify-introduced
    regressions shall be diagnosed and fixed before proceeding.
-5. **Handoff to Phase 5b.** Phase 5a transitions to `/security-review`
-   so security scans the final, simplified code.
+5. **Handoff to Phase 5b.** Phase 5a transitions to the security gate so
+   security scans the final, simplified code.
 
 ## Phase 5b: Security Review (mandatory gate)
 
 After Phase 5a completes (or is skipped) and before pushing:
 
-1. Run `/security-review`.
-2. If `/security-review` reports findings, resolve them before
-   proceeding. Iterate until the review passes clean.
+1. Spawn one `Agent` sub-agent to perform a security review of the batch
+   diff and report findings as its final message. Do **not** invoke the
+   `/security-review` Skill (it would end this agent's turn before
+   Phase 6). For a diff that is entirely non-executable text (markdown,
+   governance docs) with no attack surface, a brief inline assessment by
+   the batch agent suffices in place of spawning the reviewer; record
+   that judgement in the status report.
+2. If the review reports findings, the batch agent resolves them in its
+   own turn before proceeding. Re-review until clean.
 3. A PR shall not be created with known security findings.
 
-## Phase 6: Deliver
+## Phase 6: Deliver (HARD COMPLETION GATE)
 
-1. Push the batch branch to origin.
+Delivery is a hard gate, not a best-effort final step. **The batch agent
+does not report success until it has pushed a branch and opened a PR.**
+A return without a PR URL is a failure, not a partial success — even if
+every prior phase passed and the work is committed. Removing the shipped
+workstream from ROADMAP.md (Phase 5 step 6) is part of this gate: the PR
+that ships the work must also remove its ROADMAP bullet. §spec:batch-delivery
+
+1. Push the batch branch to origin under its **conventional name**
+   (`<type>/<scope>-<slug>`, e.g. `feat/harden-batch-delivery`). Never
+   push under the `worktree-agent-<id>` name the isolation harness
+   assigned to this worktree — that name is an implementation artifact,
+   not a delivery branch. Create the conventional branch from the
+   current HEAD before pushing if the checked-out branch is the
+   harness-assigned one.
 2. Open a single PR. Title: `feat: batch — <summary>`.
    Body lists each workstream as a bullet with its commit message.
    Include a recommendation for the reviewer:
@@ -228,13 +272,31 @@ After Phase 5a completes (or is skipped) and before pushing:
    > Run /review --comment to post code-quality findings as PR comments.
    ```
 
-3. If `--unattended`, return the PR URL and workstream slug(s) to
-   the dispatch layer. Do not wait for review.
-   Otherwise, ask the user to review. If the project has a live-test
-   protocol (e.g., Dart MCP + DTD), prompt the user with specific
-   things to test and regressions to check.
-4. The worktree is cleaned up automatically by the Agent tool
-   when the batch agent exits.
+3. **Return the PR URL and workstream slug(s) as your final message.**
+   This is the gate's success signal. Do not end your turn before the PR
+   exists. If `--unattended`, do not wait for review; otherwise ask the
+   user to review (and, if the project has a live-test protocol such as
+   Dart MCP + DTD, prompt for specific things to test).
+4. **If delivery cannot complete** — push fails, `gh pr create` fails, or
+   any blocker prevents opening the PR — say so explicitly in your final
+   message and leave the worktree committed. Do not report success. The
+   dispatch layer's recovery path (see `commands/next.md`) adopts the
+   committed worktree and finishes delivery from there.
+5. The worktree is cleaned up automatically by the Agent tool when the
+   batch agent exits.
+
+### Why recovery, not resume
+
+Delivery cannot depend on the dispatch layer resuming a stalled batch
+agent in-band. `SendMessage`-based resume is gated behind Claude Code's
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, which is off by default and —
+because the gate is read at module init — takes effect only through a
+shell-level environment export before launch, not through
+`settings.json`. It is also version-dependent. So in the common
+configuration there is no way to drive a stalled batch agent to
+completion. The batch agent's commits in the worktree are the durable
+source of truth; if this agent fails to deliver, recovery happens from
+those commits, not by resuming this turn. §spec:batch-delivery
 
 ## Principles
 
@@ -285,9 +347,11 @@ The batch agent owns the git work for the slice:
 
 - Work on a feature branch — never commit to the trunk. One logical
   unit of work per branch (the batch). Branch naming
-  `<type>/<short-description>` matches the commit scope (e.g.
-  `feat/buffer-aware-execution`). Create from `origin/$trunk` (the
-  resolved trunk, Phase 2).
+  `<type>/<scope>-<slug>` matches the commit scope (e.g.
+  `feat/buffer-aware-execution`), never the `worktree-agent-<id>` name
+  the isolation harness assigns. Create from `origin/$trunk` (the
+  resolved trunk, Phase 2); deliver under the conventional name
+  (Phase 6).
 - One logical change per commit. If a commit message needs "and,"
   split it into two commits. Use conventional commits:
   `<type>(<scope>): <description>`, where type is one of


### PR DESCRIPTION
Hardens batch delivery so every dispatched batch ends in a reviewable PR or an explicit failure — never a silent no-op. Implements §spec:batch-delivery (now complete), closes §road:harden-batch-delivery.

## Changes

**plugins/conduct/protocols/batch-agent.md**
- Phase 6 is now a hard completion gate: the batch agent reports success only after pushing a branch and opening a PR. A return without a PR URL is a failure, not partial success. Removing the shipped ROADMAP workstream (Phase 5 step 6) is part of the gate.
- Quality gates (Phase 5a simplify, 5b security) run as `Agent` sub-agents whose results return as tool results — never as `/simplify` or `/security-review` Skills. A Skill invoked inside a sub-agent ends its turn, making every later phase (including delivery) unreachable (the stall behind #165 and #171). Rationale captured inline as `skill-ends-sub-agent-turn`.
- Delivery branches use the conventional `<type>/<scope>-<slug>` name, never the harness-assigned `worktree-agent-<id>`.
- New "Why recovery, not resume" note: `SendMessage` resume is not assumable (gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, read at module init so it needs a shell export not `settings.json`, version-dependent).

**plugins/conduct/commands/next.md**
- New "Recovery — incomplete delivery" path: when the agent returns without a PR URL, the dispatch layer adopts the committed worktree and finishes delivery itself (verify work, remove shipped ROADMAP workstream, re-run CI, push to a conventional branch, open the PR) rather than resuming the sub-agent. The `assembled:governance-root` fragment block is untouched.

**SPEC.md / ROADMAP.md**
- §spec:batch-delivery set to complete; shipped workstream removed from ROADMAP.

## Verification

This is a text/protocol behavior change, so verification is wording-correctness + lint + reasoning:
- batch-agent.md states Phase 6 as a hard gate (no return without a PR URL) and the no-resume note. next.md has the Recovery path with all required steps.
- `npx markdownlint-cli2` over the changed files introduces zero new errors (5 pre-existing in next.md, unchanged in count and rule, outside CI's governance-only markdownlint globs).
- `§spec:batch-delivery`, `§spec:simplify-gate`, `§req:success-criteria` all resolve to headings.
- `tools/assemble-fragments.sh` re-assembly produced no fragment drift; the governance-root fragment block in next.md is unchanged.
- Phase 5a simplify skipped (all changed paths non-source). Phase 5b security: inline assessment — non-executable markdown, no attack surface, no findings.

Fixes #132

> Run /review --comment to post code-quality findings as PR comments.