### PR TITLE
docs(spec): triage #131 — modal-verb discipline is document-wide

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,3 +39,28 @@ delegate-freshness contract in `plugins/notation/commands/init.md`.
 the contract; governance-lint passes. The dependabot scaffolding lives with
 the `init` scaffolder, now in `plugins/notation/commands/init.md`.
 
+## Prose-linting scope alignment §road:prose-linting-scope
+
+### Align modal-verb guidance with document-wide Vale rule §road:modal-verb-scope
+
+The writing guidance in `plugins/compose/commands/plan.md` and
+`plugins/compose/commands/discover.md` scopes `shall` to *criteria*
+only, while the `/notation:init`-scaffolded Vale rule
+(`styles/Requirements/MustDeprecated.yml`) flags `must` document-wide
+at error level. `/discover` and `/plan` write idiomatic narrative
+`must`, which is green locally (the governance-lint script skips
+Vale) but fails CI. Broaden the modal-verb guidance in both commands
+to steer *all* SPEC.md / REQUIREMENTS.md prose — narrative included —
+away from `must`/`will`, and reconcile the README claim
+(README.md:126) with the document-wide scope. Reported in #131.
+§spec:prose-linting
+
+**Verify:** In a project scaffolded by `/notation:init`, run
+`/compose:discover` and `/compose:plan` to produce REQUIREMENTS.md /
+SPEC.md containing narrative that would idiomatically use `must`.
+Confirm the generated prose uses `shall`/`should` (or rephrases) and
+that `vale SPEC.md REQUIREMENTS.md` reports zero
+`Requirements.MustDeprecated` errors. Confirm `plan.md`,
+`discover.md`, and §spec:prose-linting agree that modal discipline
+is document-wide. Governance-lint passes.
+

--- a/SPEC.md
+++ b/SPEC.md
@@ -210,13 +210,30 @@ translation from requirements to spec is where design decisions
 happen — that boundary should be explicit.
 
 ## Prose linting §spec:prose-linting
-*Status: complete*
+*Status: in progress*
 
 The governance-lint workflow validates structure (markdownlint) and
 cross-references (slug resolution), but not prose quality. SPEC.md
 and REQUIREMENTS.md use IEEE modal verbs — "shall" for mandatory
 requirements, "should" for recommendations, "may" for permission.
 `Must` and `will` are deprecated per IEEE SA Standards Style Manual.
+
+Modal-verb discipline applies document-wide, not only to criteria.
+The scaffolded `Requirements` Vale style flags `must` (and `will`)
+in any sentence of SPEC.md / REQUIREMENTS.md, including narrative
+problem statements, context, and rationale. The writing commands
+(`/compose:discover`, `/compose:plan`) therefore steer all prose in
+these files away from `must`/`will` — not the criteria alone — so
+generated documents pass the scaffolded Vale style on the first
+push.
+
+**Why document-wide:** Vale matches tokens per sentence; it cannot
+reliably tell a requirement line ("the system shall…") from
+narrative (`the user must re-map each header`). Scoping the rule to
+criteria-only is not mechanically feasible, so the prose guidance
+matches the rule's actual reach. Aligning the guidance to the
+linter is cheaper and more robust than weakening the linter
+(reported in #131).
 
 Vale (<https://vale.sh>) enforces prose rules via custom YAML
 styles. A `Requirements` style checks modal verb compliance, flags


### PR DESCRIPTION
Triage of #131. Classification: **bug revealing a design gap**.

`§spec:prose-linting` never stated whether IEEE modal-verb discipline applies document-wide or only to criteria. The `/notation:init`-scaffolded Vale rule (`styles/Requirements/MustDeprecated.yml`) flags `must`/`will` in any sentence of SPEC.md / REQUIREMENTS.md at error level, but the `/compose:discover` and `/compose:plan` writing guidance scopes `shall` to *criteria* only. So those commands emit idiomatic narrative `must`, which passes locally (the governance-lint script skips the Vale Go binary) and fails CI — a recurring push→fail→fix→push every planning pass.

## Changes
- **SPEC.md** — amend `§spec:prose-linting` (`complete` → `in progress`): modal discipline applies document-wide; the writing commands steer *all* prose away from `must`/`will`, not criteria alone. Rationale: Vale matches per-sentence and cannot tell a requirement line from narrative, so scoping the rule to criteria-only is not feasible — align the guidance to the linter's reach instead of weakening the linter.
- **ROADMAP.md** — new `§road:modal-verb-scope` workstream under `§spec:prose-linting` to broaden the guidance in plan.md/discover.md and reconcile the README claim, with a `**Verify:**` block.

No fix shipped here — `/next` implements `§road:modal-verb-scope` and closes #131 with `Fixes #131`.

Vale and markdownlint pass locally on the edited files.