### PR TITLE
docs(roadmap): triage #128 — infer batch delivery branch type

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,3 +64,26 @@ that `vale SPEC.md REQUIREMENTS.md` reports zero
 `discover.md`, and §spec:prose-linting agree that modal discipline
 is document-wide. Governance-lint passes.
 
+## Batch delivery branch-type inference §road:batch-branch-type
+
+### Infer delivered branch and PR title type from batch commits §road:batch-delivery-type-inference
+
+`plugins/conduct/protocols/batch-agent.md` Phase 6 hardcodes the
+delivery type to `feat` — the branch example is `feat/<slug>` (step 1)
+and the PR title is `feat: batch — <summary>` (step 2) — even when the
+batch contains only `fix` commits. Under conventional-commit
+semantics the umbrella type should match the batch's highest-severity
+commit type, so release-please versions the squashed merge correctly
+(a fix-only batch cuts a patch, not a minor). Derive `<type>` for both
+the delivered branch name and the PR title from the batch's actual
+commit types. Surfaced while triaging #128, whose primary defect — the
+`worktree-agent-<id>` branch leak — is already fixed by
+§spec:batch-delivery (PR #174). §spec:batch-delivery
+
+**Verify:** Run a batch whose workstreams produce only `fix` commits;
+confirm the delivered branch is `fix/<scope>-<slug>` and the PR title
+is `fix: batch — <summary>`. Run a batch containing at least one
+`feat`; confirm the umbrella type is `feat`. `batch-agent.md` Phase 6
+and §spec:batch-delivery agree the delivered type is derived, not
+hardcoded. Governance-lint passes.
+


### PR DESCRIPTION
Triage of #128. Classification: **already-resolved bug, with a residual nuance tracked**.

## Already fixed
#128's primary defect — batch-agent Phase 6 pushing the `worktree-agent-<id>` isolation branch as the PR head (which auto-closes the PR on rename) — already shipped in **#174** (`dd7a41a`, 2026-06-08), four days after #128 was filed. It's covered by:
- `§spec:batch-delivery` criterion: *Delivered branches use the conventional name … never the `worktree-agent-<id>` name.*
- `batch-agent.md` Phase 6 step 1: push under the conventional name, creating it from HEAD if the checked-out branch is harness-assigned.

#128 stayed open only because #174 carried `Fixes #132`, not `Fixes #128`.

## Residual nuance (this PR)
Phase 6 still hardcodes the delivery type to `feat` for both the branch (`feat/<slug>`) and the PR title (`feat: batch — …`), even for fix-only batches — which mis-versions the squashed merge under release-please. Tracked as `§road:batch-delivery-type-inference` for `/next` to implement.

No fix shipped here. Governance-lint (heading-addressing + markdownlint) passes locally.