### PR TITLE
docs(spec): batch agent is a fan-out leaf — triage + plan

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,3 +87,33 @@ is `fix: batch — <summary>`. Run a batch containing at least one
 and §spec:batch-delivery agree the delivered type is derived, not
 hardcoded. Governance-lint passes.
 
+## Batch agent fan-out locus §road:batch-agent-leaf
+
+### Relocate review gates and delivery to the dispatch layer §road:relocate-gates-to-dispatch
+
+Rewrite `plugins/conduct/protocols/batch-agent.md` so the batch agent is a
+fan-out leaf: Phase 3 executes workstreams inline and sequentially (no
+per-workstream sub-agent spawn); Phases 5a (`/simplify`) and 5b
+(`/security-review`) leave the protocol; Phase 6 returns a committed branch and
+status report instead of opening a PR. Move the review gates and PR delivery
+into `plugins/conduct/commands/next.md` as the dispatch layer's primary path —
+run `/simplify` then `/security-review` against the returned branch, apply
+fixes, re-run CI, then open the PR — generalizing the existing recovery path
+(§spec:batch-delivery) into the standard delivery path. Revise
+§spec:simplify-gate, §spec:pre-pr-review-gates, and §spec:batch-delivery to
+relocate the gate locus, flipping each with §spec:batch-agent-leaf as it reaches
+completion. Sequence after or coordinate with §road:migrate-orchestrate-to-goal
+and §road:batch-delivery-type-inference, which also edit batch-agent.md.
+§spec:batch-agent-leaf
+
+**Verify:** Run `/conduct:next` on a populated ROADMAP section. Confirm: (1) the
+batch agent spawns no sub-agents and returns a committed branch with no PR; (2)
+the dispatch layer runs `/simplify` and `/security-review` against that branch
+and applies fixes; (3) a single PR opens only after the gates pass, with the
+shipped workstream removed from ROADMAP.md; (4) a batch carrying a security
+finding does not reach an open PR until resolved.
+`grep -n 'Phase 5a\|Phase 5b\|/simplify\|/security-review' plugins/conduct/protocols/batch-agent.md`
+returns no matches; the gate steps live in `next.md`. batch-agent.md, next.md,
+and the three revised spec sections agree the batch agent is a leaf.
+Governance-lint passes.
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,27 +93,36 @@ hardcoded. Governance-lint passes.
 
 Rewrite `plugins/conduct/protocols/batch-agent.md` so the batch agent is a
 fan-out leaf: Phase 3 executes workstreams inline and sequentially (no
-per-workstream sub-agent spawn); Phases 5a (`/simplify`) and 5b
-(`/security-review`) leave the protocol; Phase 6 returns a committed branch and
-status report instead of opening a PR. Move the review gates and PR delivery
-into `plugins/conduct/commands/next.md` as the dispatch layer's primary path —
-run `/simplify` then `/security-review` against the returned branch, apply
-fixes, re-run CI, then open the PR — generalizing the existing recovery path
-(§spec:batch-delivery) into the standard delivery path. Revise
-§spec:simplify-gate, §spec:pre-pr-review-gates, and §spec:batch-delivery to
-relocate the gate locus, flipping each with §spec:batch-agent-leaf as it reaches
-completion. Sequence after or coordinate with §road:migrate-orchestrate-to-goal
-and §road:batch-delivery-type-inference, which also edit batch-agent.md.
+per-workstream sub-agent spawn); Phases 5a (`/simplify`), 5b
+(`/security-review`), and the "Quality gates run as sub-agents, never as Skills"
+section leave the protocol; Phase 6 returns a pushed branch and status report
+instead of opening a PR. Move the review gates and PR delivery into
+`plugins/conduct/commands/next.md` as the dispatch layer's primary path — run
+the `/simplify` then `/security-review` **Skills** (legal in the main session,
+which has a session loop) against the returned branch in an isolated worktree,
+apply fixes, re-run CI, then open the PR — promoting the existing recovery path
+(§spec:batch-delivery) to the standard delivery path and replacing next.md's
+"not the orchestrator" framing. Revise §spec:simplify-gate,
+§spec:pre-pr-review-gates, and §spec:batch-delivery to relocate the gate locus
+and supersede the "run gates as Agent sub-agents" mechanism; remove the
+"worktree sub-agents descend from the batch integration HEAD" half of
+§spec:integration-ref (no workstream sub-agents remain to base; its
+trunk-resolution half stays). Flip each affected section with
+§spec:batch-agent-leaf as the work reaches completion. Sequence after or
+coordinate with §road:migrate-orchestrate-to-goal and
+§road:batch-delivery-type-inference, which also edit batch-agent.md.
 §spec:batch-agent-leaf
 
 **Verify:** Run `/conduct:next` on a populated ROADMAP section. Confirm: (1) the
-batch agent spawns no sub-agents and returns a committed branch with no PR; (2)
-the dispatch layer runs `/simplify` and `/security-review` against that branch
-and applies fixes; (3) a single PR opens only after the gates pass, with the
-shipped workstream removed from ROADMAP.md; (4) a batch carrying a security
-finding does not reach an open PR until resolved.
-`grep -n 'Phase 5a\|Phase 5b\|/simplify\|/security-review' plugins/conduct/protocols/batch-agent.md`
-returns no matches; the gate steps live in `next.md`. batch-agent.md, next.md,
-and the three revised spec sections agree the batch agent is a leaf.
-Governance-lint passes.
+batch agent spawns no sub-agents and returns a pushed branch with no PR; (2) the
+dispatch layer runs the `/simplify` and `/security-review` Skills against that
+branch and applies fixes without touching the user's main checkout; (3) a single
+PR opens only after the gates pass, with the shipped workstream removed from
+ROADMAP.md; (4) a batch carrying a security finding does not reach an open PR
+until resolved.
+`grep -n 'Phase 5a\|Phase 5b\|sub-agent per workstream' plugins/conduct/protocols/batch-agent.md`
+returns no matches; the gate and delivery steps live in `next.md`. batch-agent.md,
+next.md, and the revised spec sections (§spec:simplify-gate,
+§spec:pre-pr-review-gates, §spec:batch-delivery, §spec:integration-ref) agree the
+batch agent is a leaf. Governance-lint passes.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -670,6 +670,89 @@ concerns. Spending three agent spawns on prose is noise.
 - Simplify may propose fixes the batch agent must revert, costing
   review time. Bounded by running simplify once.
 
+## Batch agent is a fan-out leaf §spec:batch-agent-leaf
+*Status: not started*
+
+Claude Code permits one level of sub-agent delegation. A sub-agent has no Agent
+tool and cannot spawn further sub-agents (Claude Code subagents documentation:
+"Subagents cannot spawn other subagents"). The batch agent dispatched by
+`/conduct:next` is itself a sub-agent (an `Agent` worktree), so it is a leaf: it
+cannot fan out.
+
+Three `complete` sections specify behavior that depends on the batch agent
+spawning sub-agents, which the runtime forbids:
+
+- `§spec:simplify-gate` runs `/simplify` as Phase 5a — "spawns three parallel
+  review agents" — inside the batch agent.
+- `§spec:pre-pr-review-gates` runs `/security-review` as a gate between Phase 5
+  and Phase 6, inside the batch agent.
+- `§spec:batch-delivery` resolves the Skill-ends-turn stall by running the gates
+  as `Agent` sub-agents rather than Skills — a mechanism a leaf cannot invoke.
+
+Each gate therefore has no legal in-batch implementation: a Skill ends the
+agent's turn before delivery (the original stall), and an `Agent` reviewer
+cannot be spawned at all, degrading to an inline self-review that forfeits the
+independent-reviewer signal the gate exists to provide. The same constraint
+makes Phase 3's "spawn one sub-agent per workstream" a silent no-op.
+
+### Observable behavior
+
+- **The batch agent executes inline.** It runs and integrates its workstreams
+  sequentially in its own turn; it spawns no sub-agents. Vertical-first
+  selection (`§spec:vertical-first-batch-selection`) makes each batch a
+  dependency chain, sequential by construction, so inline execution forfeits no
+  available parallelism.
+- **Review gates run at the dispatch layer.** The `/conduct:next` orchestrator —
+  the main session, which has a session loop — runs `/simplify` and
+  `/security-review` against the branch the batch agent returns. It may run them
+  as independent sub-agents or as Skills; both are legal in the main session,
+  and both give cold reviewers that did not write the code.
+- **Delivery runs at the dispatch layer.** The batch agent's completion signal
+  is a committed branch plus a status report, not a PR. The orchestrator runs
+  the gates, applies fixes, re-runs CI, removes the shipped ROADMAP workstream,
+  and opens the PR. Review precedes PR creation, so "a PR shall not be created
+  with known security findings" (`§spec:pre-pr-review-gates`) holds without the
+  gate running inside the batch agent.
+
+### Why warm worker, cold reviewers
+
+The batch agent stays warm: it carries the plan and integration context across
+Phases 1–5 in one window, so inline sequential work is cheap. The reviewers are
+cold by design — independence is the purpose of a review gate, and a reviewer
+sharing the author's context cannot supply it. The seam between warm and cold is
+the committed branch the batch agent returns. Splitting the worker into cold
+fragments would harm the worker and add nothing for the reviewers.
+
+### Why dispatch-layer delivery, not batch-agent delivery
+
+`§spec:batch-delivery` already has the dispatch layer adopt a batch agent's
+committed worktree and finish delivery when the agent returns without a PR —
+today a recovery path from a stall. This section promotes it from fallback to
+primary: the batch agent always stops at a committed branch, and the dispatch
+layer always delivers. One delivery path, exercised every batch, replaces a
+primary path that cannot run and a recovery path that runs only on failure.
+
+### Rejected alternative: full flatten
+
+Dissolve the batch agent; have the dispatch layer spawn workstream workers and
+reviewers directly. Rejected: it fragments the warm worker into cold per-step
+boundaries (higher token and latency cost), moves integration churn —
+cherry-picks, conflict resolution, CI loops — into the interactive session the
+batch agent exists to isolate, and distributes the recovery anchor across many
+worktrees. Its sole gain is workstream parallelism, which vertical-chain
+selection is built not to produce. Revisit only if batch selection changes to
+prefer wide independent sets over vertical chains.
+
+### Scope
+
+The contract spans `plugins/conduct/protocols/batch-agent.md` (Phase 3 becomes
+inline; Phases 5a, 5b, and 6 leave the protocol) and
+`plugins/conduct/commands/next.md` (the dispatch layer gains the gate and
+delivery steps as its primary path). Implementing this relocates the gate locus
+in `§spec:simplify-gate`, `§spec:pre-pr-review-gates`, and
+`§spec:batch-delivery`. Reported by the maintainer during architecture review,
+corroborated by an observed inline-review fallback in a batch run.
+
 ## Thin roadmap workstreams §spec:thin-roadmap-workstreams
 *Status: complete*
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -679,8 +679,13 @@ tool and cannot spawn further sub-agents (Claude Code subagents documentation:
 `/conduct:next` is itself a sub-agent (an `Agent` worktree), so it is a leaf: it
 cannot fan out.
 
-Three `complete` sections specify behavior that depends on the batch agent
-spawning sub-agents, which the runtime forbids:
+The conduct protocol assumed two levels of delegation: the dispatch layer spawns
+the batch agent, which spawns workstream and reviewer sub-agents. The second
+level cannot run, and the defect is not confined to the review gates —
+`plugins/conduct/protocols/batch-agent.md` Phase 3 ("spawn one sub-agent per
+workstream") is equally unspawnable and degrades silently to inline work. Three
+further `complete` sections specify behavior that depends on the forbidden second
+level:
 
 - `§spec:simplify-gate` runs `/simplify` as Phase 5a — "spawns three parallel
   review agents" — inside the batch agent.
@@ -692,27 +697,53 @@ spawning sub-agents, which the runtime forbids:
 Each gate therefore has no legal in-batch implementation: a Skill ends the
 agent's turn before delivery (the original stall), and an `Agent` reviewer
 cannot be spawned at all, degrading to an inline self-review that forfeits the
-independent-reviewer signal the gate exists to provide. The same constraint
-makes Phase 3's "spawn one sub-agent per workstream" a silent no-op.
+independent-reviewer signal the gate exists to provide.
+
+### The dispatch layer is the orchestrator
+
+Anything that needs to fan out, or needs a session loop to survive a Skill
+invocation, runs at the top-level orchestrator — the `/conduct:next` dispatch
+layer, which executes in the main session. The batch agent is a leaf worker; the
+dispatch layer owns every operation the leaf cannot perform. This reframes the
+dispatch layer from a thin selector that spawns one agent and recovers on failure
+into the orchestrator of work, review, and delivery.
 
 ### Observable behavior
 
-- **The batch agent executes inline.** It runs and integrates its workstreams
-  sequentially in its own turn; it spawns no sub-agents. Vertical-first
-  selection (`§spec:vertical-first-batch-selection`) makes each batch a
-  dependency chain, sequential by construction, so inline execution forfeits no
-  available parallelism.
-- **Review gates run at the dispatch layer.** The `/conduct:next` orchestrator —
-  the main session, which has a session loop — runs `/simplify` and
-  `/security-review` against the branch the batch agent returns. It may run them
-  as independent sub-agents or as Skills; both are legal in the main session,
-  and both give cold reviewers that did not write the code.
-- **Delivery runs at the dispatch layer.** The batch agent's completion signal
-  is a committed branch plus a status report, not a PR. The orchestrator runs
-  the gates, applies fixes, re-runs CI, removes the shipped ROADMAP workstream,
-  and opens the PR. Review precedes PR creation, so "a PR shall not be created
-  with known security findings" (`§spec:pre-pr-review-gates`) holds without the
-  gate running inside the batch agent.
+- **The batch agent executes inline and returns a branch.** It plans,
+  implements, integrates, and verifies its workstreams sequentially in its own
+  turn (Phases 1–5), spawning no sub-agents. Its completion signal is a pushed
+  branch and a status report, not a PR. Vertical-first selection
+  (`§spec:vertical-first-batch-selection`) makes each batch a dependency chain,
+  sequential by construction, so inline execution forfeits no available
+  parallelism.
+- **Review gates run at the dispatch layer as Skills.** After the batch agent
+  returns, the dispatch layer runs `/simplify` then `/security-review` as Skills.
+  The main session has a session loop, so a Skill returns control rather than
+  ending the turn, and the Skills run at full fidelity — `/simplify`'s own
+  parallel review agents fan out because the main session can spawn them. The
+  reviewers are cold: they did not write the code, which is the property a gate
+  exists to provide.
+- **Review and delivery never touch the user's main checkout.** The dispatch
+  layer runs the gates and applies fixes against the batch's branch in an
+  isolated worktree, not the user's working tree, preserving worktree-only
+  execution.
+- **Delivery runs at the dispatch layer.** Once the gates pass, the dispatch
+  layer applies fixes, re-runs CI, removes the shipped ROADMAP workstream, and
+  opens the PR. Review precedes PR creation, so "a PR shall not be created with
+  known security findings" (`§spec:pre-pr-review-gates`) holds. Every batch ends
+  in a reviewed PR or an explicit failure — the guarantee `§spec:batch-delivery`
+  established, relocated from the batch agent to the dispatch layer.
+
+### Why gates are Skills at the dispatch layer
+
+The gates were always Skills; the prior design's error was running them where a
+Skill cannot survive. `§spec:batch-delivery` diagnosed the Skill-ends-turn stall
+correctly but reimplemented the gates as `Agent` sub-agents to keep them inside
+the batch agent — a mechanism a leaf cannot invoke. Relocating the gates to the
+session that has a loop removes the reimplementation: the native `/simplify` and
+`/security-review` Skills run unchanged. The fix is simpler than the design it
+replaces, not more complex.
 
 ### Why warm worker, cold reviewers
 
@@ -720,17 +751,19 @@ The batch agent stays warm: it carries the plan and integration context across
 Phases 1–5 in one window, so inline sequential work is cheap. The reviewers are
 cold by design — independence is the purpose of a review gate, and a reviewer
 sharing the author's context cannot supply it. The seam between warm and cold is
-the committed branch the batch agent returns. Splitting the worker into cold
-fragments would harm the worker and add nothing for the reviewers.
+the branch the batch agent returns. Splitting the worker into cold fragments
+would harm the worker and add nothing for the reviewers.
 
 ### Why dispatch-layer delivery, not batch-agent delivery
 
 `§spec:batch-delivery` already has the dispatch layer adopt a batch agent's
 committed worktree and finish delivery when the agent returns without a PR —
 today a recovery path from a stall. This section promotes it from fallback to
-primary: the batch agent always stops at a committed branch, and the dispatch
-layer always delivers. One delivery path, exercised every batch, replaces a
-primary path that cannot run and a recovery path that runs only on failure.
+primary: the batch agent always stops at a returned branch, and the dispatch
+layer always gates and delivers. One delivery path, exercised every batch,
+replaces a primary path that could not run and a recovery path that ran only on
+failure. The hard-completion guarantee is unchanged in force; only its locus
+moves.
 
 ### Rejected alternative: full flatten
 
@@ -745,13 +778,27 @@ prefer wide independent sets over vertical chains.
 
 ### Scope
 
-The contract spans `plugins/conduct/protocols/batch-agent.md` (Phase 3 becomes
-inline; Phases 5a, 5b, and 6 leave the protocol) and
-`plugins/conduct/commands/next.md` (the dispatch layer gains the gate and
-delivery steps as its primary path). Implementing this relocates the gate locus
-in `§spec:simplify-gate`, `§spec:pre-pr-review-gates`, and
-`§spec:batch-delivery`. Reported by the maintainer during architecture review,
-corroborated by an observed inline-review fallback in a batch run.
+Implementing this design:
+
+- Rewrites `plugins/conduct/protocols/batch-agent.md`: Phase 3 becomes inline
+  sequential execution; Phases 5a, 5b, and the "Quality gates run as sub-agents,
+  never as Skills" section are removed; Phase 6 returns a pushed branch instead
+  of opening a PR.
+- Rewrites `plugins/conduct/commands/next.md`: the dispatch layer gains the gate
+  and delivery steps as its primary path, replacing the "not the orchestrator"
+  framing.
+- Relocates the gate locus in `§spec:simplify-gate` and
+  `§spec:pre-pr-review-gates` — the gates run as dispatch-layer Skills; their
+  why-mandatory and ordering rationale survive.
+- Supersedes `§spec:batch-delivery`'s "run gates as `Agent` sub-agents" mechanism
+  and moves its hard-completion gate to the dispatch layer.
+- Obsoletes the "worktree sub-agents descend from the batch integration HEAD"
+  contract in `§spec:integration-ref`: with no workstream sub-agents, there is no
+  sub-agent base to manage. The trunk-resolution half of that section is
+  unaffected.
+
+Reported by the maintainer during architecture review, corroborated by an
+observed inline-review fallback in a batch run.
 
 ## Thin roadmap workstreams §spec:thin-roadmap-workstreams
 *Status: complete*


### PR DESCRIPTION
Triage + plan for an architecture-review finding (no GitHub issue; reported by the maintainer during discussion). Two commits:

1. `docs(spec): triage` — route the finding into governance.
2. `docs(spec): plan` — design resolution (`/compose:plan §spec:batch-agent-leaf`).

## The finding

A batch agent dispatched by `/conduct:next` is itself a sub-agent (an `Agent` worktree). Claude Code permits one level of sub-agent delegation — a sub-agent has no `Agent` tool and cannot spawn further sub-agents. So the conduct protocol's two-tier model (dispatch → batch agent → workstream/reviewer sub-agents) cannot run as written. The defect spans:

- **Phase 3 fan-out** (`batch-agent.md`) — "spawn one sub-agent per workstream" silently degrades to inline.
- **`§spec:simplify-gate`** — `/simplify` Phase 5a "spawns three parallel review agents" inside the batch agent.
- **`§spec:pre-pr-review-gates`** — `/security-review` gate inside the batch agent.
- **`§spec:batch-delivery`** — resolves the Skill-ends-turn stall by running gates as `Agent` sub-agents, which a leaf cannot invoke.
- **`§spec:integration-ref`** — its "worktree sub-agents descend from the batch integration HEAD" contract presupposes workstream sub-agents that inline Phase 3 removes.

Both in-batch options fail: a Skill ends the agent's turn before delivery (the #165/#171 stall), and an `Agent` reviewer can't be spawned (degrades to inline self-review — observed in a recent run).

## Design (compose:plan)

`§spec:batch-agent-leaf` (SPEC.md, *not started*) is now the authoritative locus section. Resolved decisions:

- **Gates run as their native Skills at the dispatch layer**, not ad-hoc `Agent` reviewers. The main session has a session loop, so `/simplify` and `/security-review` run at full fidelity and return control. This obsoletes `§spec:batch-delivery`'s `Agent`-sub-agent reimplementation — the fix is simpler than the design it replaces.
- **Delivery relocates to the dispatch layer.** The batch agent returns a pushed branch (no PR); the dispatch layer gates against it in an isolated worktree (never the user's main checkout), then opens the PR. `§spec:batch-delivery`'s recovery path is promoted from fallback to primary; the hard-completion guarantee relocates, unchanged in force.
- **The dispatch layer is reframed as the orchestrator** of work, review, and delivery — replacing `next.md`'s "not the orchestrator" directive (prose-only, not a spec criterion).

`§road:relocate-gates-to-dispatch` (ROADMAP.md) carries the implementation scope across `batch-agent.md`, `next.md`, and the four affected spec sections.

The four affected `complete` sections are left intact in this PR — they describe the currently-running behavior; `§spec:batch-agent-leaf` and the roadmap workstream name them for revision when `/conduct:next` implements. Sequence after / coordinate with `§road:migrate-orchestrate-to-goal` and `§road:batch-delivery-type-inference`, which also edit `batch-agent.md`.

Governance-lint (status lines, heading-addressing grammar, Vale, markdownlint) passes locally. No behavior ships here.

> Run /review --comment to post code-quality findings as PR comments.