### PR TITLE
docs(requirements): triage #115 — local/CI lint parity criterion

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -217,6 +217,13 @@ Success looks like:
   interpreted document is judged by whether it parses and reads
   coherently, not held to the checks compiled code requires.
   §req:quality-attributes
+- The contract CI enforces is verifiable **before the push**, not only
+  after it. A contributor catches a dangling `§`-reference, a missing
+  status line, or a malformed slug at edit time, rather than waiting on
+  a CI round-trip for checks that are cheap to run locally. Local
+  verification and CI enforce one contract — what passes locally
+  predicts what passes in CI — so the two never drift. Surfaced by #115.
+  §req:quality-attributes
 
 CHANGELOG.md is out of scope: release-please generates it, so it is
 neither authored by the tastemaking process nor interpreted as


### PR DESCRIPTION
Triage of #115. Classification: **feature request** exposing a spec/requirement mismatch.

## What #115 asks
The full governance contract (Vale, SPEC status lines, `§spec:`/`§road:`/`§req:` slug grammar + cross-reference resolution, README heading profile) runs only as inline bash in `governance-lint.yml` at CI time. Locally, both `/notation:lint` and the scaffolded `.githooks/pre-commit` run **markdownlint only** — so a contributor discovers a dangling `§`-reference or missing status line only after a push + CI round-trip.

## Why this is a requirements edit, not a new section
The "why" already exists: **§req:low-friction-governance** promises governance changes "land correct by construction — they parse, lint, and cross-resolve before they reach GitHub." Today only markdownlint resolves locally; the checks that requirement names are CI-only. Rather than duplicate the requirement, this adds one success criterion making local/CI parity explicit.

The *design* — extracting the inline checks into a single shared script that CI, the pre-commit hook, and `/notation:lint` all call — is `/plan`'s job (decisions: script language, repo vs plugin-bundle location, staged-file scoping, whether Vale is in the local subset). 

**Next step:** `/plan` to design the shared-lint extraction against §spec:governance-lint / §spec:reusable-ci / §spec:project-scaffolding.

markdownlint + Vale pass locally.