### PR TITLE
feat: parameterize release automation — flywheel default (spec + roadmap)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,3 +87,47 @@ is `fix: batch — <summary>`. Run a batch containing at least one
 and §spec:batch-delivery agree the delivered type is derived, not
 hardcoded. Governance-lint passes.
 
+## Parameterized release scaffolding §road:release-automation-scaffolding
+
+### Create per-tool scaffold templates §road:release-templates
+
+Add `templates/flywheel/` (`flywheel-pr.yml`, `flywheel-push.yml`,
+`.flywheel.yml`), move the existing release-please workflows into
+`templates/release-please/`, and define `templates/manual/` (no
+release-automation files), keeping symphonize's own `.github/workflows/*`
+as the dogfooded release-please source. §spec:release-automation-options
+§spec:reusable-ci
+
+### Tool selection in /notation:init §road:init-release-selection
+
+Add the release-automation prompt (flywheel default), copy from the chosen
+`templates/<tool>/`, and detect the existing choice from `.flywheel.yml` /
+`release-please-config.json` to skip the prompt on re-run, in
+`plugins/notation/commands/init.md`. Depends on §road:release-templates.
+§spec:release-automation-options
+
+**Verify:** In a fresh repo, run `/notation:init` and accept the default —
+confirm it scaffolds `.flywheel.yml` and the flywheel workflows and no
+release-please files. Run it again — confirm it detects flywheel and skips
+the prompt, scaffolding only missing files. In separate fresh repos, select
+release-please (confirm `release-please-config.json` + workflows) and manual
+(confirm no release-automation files, but CHANGELOG.md still carries
+`[Unreleased]`). Governance-lint passes.
+
+## Release-aware clean checks §road:release-aware-clean
+
+### Per-tool release check in /conduct:clean §road:clean-release-check
+
+Detect the release tool from `.flywheel.yml` / `release-please-config.json`
+/ neither and run the matching advisory check (flywheel eligibility, next
+release-please PR, or manual CHANGELOG/tag reminder) in
+`plugins/conduct/commands/clean.md`, mirroring the re-run detection signals
+in §road:init-release-selection. §spec:release-automation-options
+
+**Verify:** Run `/conduct:clean` in a flywheel-scaffolded repo with
+unreleased commits — confirm it reports the commits are eligible for a
+managed-branch release. In a release-please repo — confirm it reports the
+next release PR picks up the commits. In a manual repo — confirm it checks
+CHANGELOG.md `[Unreleased]` and reminds to tag. The check reads repo state
+and does not invoke the release tool. Governance-lint passes.
+

--- a/SPEC.md
+++ b/SPEC.md
@@ -6,7 +6,7 @@
 Symphonize provides Claude Code plugin commands that operate on
 the governance file loop (REQUIREMENTS.md → SPEC.md → ROADMAP.md
 → CHANGELOG.md) and produce conventional commits suitable for
-release-please.
+downstream release automation (§spec:release-automation-options).
 
 The commands distribute across four plugins (§spec:governance-schema),
 grouped here by plugin:
@@ -89,10 +89,10 @@ The command creates:
 - `.markdownlint.json` — default config
 - `.github/workflows/governance-lint.yml` — caller workflow
   referencing `repentsinner/symphonize/.github/workflows/governance-lint.yml@notation--v0`
-- `.github/workflows/release-please.yml` — release-please action
-  with config and manifest files
-- `.github/workflows/auto-merge-release.yml` — auto-merge for
-  release PRs
+- Release-automation files for the adopter's chosen tool — the set
+  depends on the choice (§spec:release-automation-options): flywheel
+  workflows + `.flywheel.yml`, release-please workflows + config and
+  manifest, or no files for manual.
 - `.githooks/pre-commit` — runs markdownlint on staged governance
   files
 
@@ -118,13 +118,20 @@ in the governance loop. Scaffolding reduces setup from "read the
 docs and copy-paste" to one command.
 
 ## Reusable CI workflows §spec:reusable-ci
-*Status: complete*
+*Status: in progress*
 
 Now the notation plugin's, under §spec:governance-schema; the workflows stay
 at the repository root `.github/workflows/` (GitHub Actions resolves reusable
 workflows only from there — §spec:plugin-packaging). Symphonize ships
 reusable GitHub Actions workflows that target projects reference via
 `workflow_call`.
+
+`governance-lint.yml` is tool-agnostic. The release workflows below are
+the release-please template set — symphonize's own dogfooded workflows
+(§spec:dogfooding), and what `/notation:init` copies when an adopter
+selects release-please. Flywheel and manual adopters scaffold a different
+file set, organized under `templates/<tool>/`
+(§spec:release-automation-options).
 
 ### governance-lint.yml
 
@@ -166,9 +173,9 @@ Symphonize ships its workflow templates two ways (§spec:reusable-ci):
 `governance-lint.yml` is scaffolded as a `@notation--v0` reusable caller
 (the notation-scoped floating major; pre-1.0, so `v0`, not `v1`), so a
 consumer picks up symphonize's internal action bumps transitively; the
-release, auto-merge, and major-tag workflows are copied verbatim because
-each needs project-specific manifests and tokens, so a consumer holds a
-point-in-time snapshot that does not self-update.
+chosen tool's release workflows (§spec:release-automation-options) are
+copied verbatim because each needs project-specific config and tokens, so
+a consumer holds a point-in-time snapshot that does not self-update.
 
 - **Source freshness — symphonize's concern.** The copied templates'
   source is symphonize's own `.github/workflows/*`, and the plugin bundle
@@ -202,6 +209,91 @@ project's to mutate; the contract's logic is symphonize's to own.
 The `init` scaffolder becomes the notation plugin's under the plugin
 decomposition (§spec:governance-schema); this freshness contract is
 notation's and moves with it. §req:modular-adoption
+
+## Release automation options §spec:release-automation-options
+*Status: not started*
+
+`/notation:init` lets the adopter choose how conventional commits become
+versioned releases. The supported options are **flywheel** (default),
+**release-please**, and **manual**. The choice determines which
+release-automation files §spec:project-scaffolding scaffolds and which
+release-aware check §spec:clean-working-tree-hygiene runs.
+
+### Selection
+
+When CWD is the repository root (CI scaffolding runs only there),
+`/notation:init` prompts: "How should releases be cut from conventional
+commits?" with the three options. The choice selects the
+`templates/<tool>/` directory to copy from. Flywheel is the default —
+taken when the adopter accepts the prompt default or runs unattended.
+Manual scaffolds no release-automation files; CHANGELOG.md still receives
+its `[Unreleased]` section.
+
+### Re-run detection
+
+`/notation:init` is idempotent (§spec:project-scaffolding). On re-run it
+detects the existing choice from repo state and skips the prompt:
+
+- `.flywheel.yml` present → flywheel.
+- `release-please-config.json` present → release-please.
+- Neither → manual.
+
+It then scaffolds only missing files. Switching tools requires removing
+the old config first; symphonize does not migrate one tool's state to
+another.
+
+### Clean integration
+
+`/conduct:clean` reads the same signals to choose its advisory
+release-aware check (§spec:clean-working-tree-hygiene):
+
+- **flywheel:** pushed conventional commits are eligible for a release on
+  the managed branch.
+- **release-please:** the next release-please PR picks up commits since
+  the last release.
+- **manual:** CHANGELOG.md `[Unreleased]` reflects merged commits, and the
+  adopter is reminded to tag.
+
+The check reads repo state; it does not invoke the release tool.
+
+### Tool comparison
+
+| Aspect | flywheel | release-please | manual |
+|---|---|---|---|
+| Release trigger | PR merge + push to managed branch | push to main | none |
+| Merge gate | per-PR (auto-merge by commit type) | per-release (release PR) | none |
+| CHANGELOG.md | semantic-release | release-please | by hand |
+| Per-repo config | `.flywheel.yml` | `release-please-config.json` + manifest | none |
+| Multi-branch streams | first-class | flat | manual |
+| Monorepo linked versions | not native (semantic-release is single-package) | native (`linked-versions`) | manual |
+
+**Why flywheel is the default:** most adopters version a single package,
+where flywheel's per-PR gate fits symphonize's tastemaking model — docs
+and chores auto-merge, features gate on review (§req:quality-attributes).
+Flywheel cuts a release per push to a managed branch, so the review gate
+sits on each PR, not on an accumulated release PR. That per-PR gate is the
+deliberate tradeoff: faster flow and earlier releases, against the loss of
+release-please's batch-a-release-then-review step.
+
+**Why release-please remains:** symphonize's own repo versions four
+plugins (notation, compose, conduct, symphonize) in lockstep via
+release-please's `linked-versions` plugin and `extra-files` write-back,
+which inject each computed version into the plugins' `plugin.json` version
+and cross-plugin dependency pins. Flywheel runs semantic-release, which is
+single-package; replicating linked lockstep versioning and JSON-path
+write-back is custom work that buys nothing. Symphonize therefore dogfoods
+release-please (§spec:dogfooding) and ships it as the monorepo option,
+while defaulting downstream single-package adopters to flywheel.
+
+**Why manual:** early-stage projects, forks, and repos where another tool
+already cuts releases opt out of release automation entirely. Without the
+option, every adopter pays GitHub App setup before `/notation:init` is
+usable.
+
+**Why detect rather than re-prompt:** matches `/notation:init`'s
+idempotent contract — skip files that exist, warn on each skip. An adopter
+switching tools removes the old config, making the switch explicit rather
+than inferred.
 
 ## Dogfooding §spec:dogfooding
 *Status: complete*


### PR DESCRIPTION
## What

Parameterizes `/notation:init`'s release-automation choice across **flywheel** (default), **release-please**, and **manual**. Carries both governance deliverables:

- **`/compose:plan`** — adds `§spec:release-automation-options` to SPEC.md, reopens `§spec:reusable-ci`, and generalizes the release-please references in `§spec:plugin-commands`, `§spec:project-scaffolding`, `§spec:scaffold-freshness`.
- **`/compose:roadmap`** — decomposes it into two vertical slices: `§road:release-automation-scaffolding` (templates/<tool>/ + init tool selection) and `§road:release-aware-clean` (per-tool `/conduct:clean` check).

## Why flywheel as default

Most adopters version a single package, where flywheel's per-PR gate fits symphonize's tastemaking model — docs/chores auto-merge, features gate on review. Deliberate tradeoff: the review gate sits on each PR (per-push releases) rather than on an accumulated release PR.

## Why not a hard cut

symphonize's own repo versions four plugins in lockstep via release-please's `linked-versions` + `extra-files` write-back. Flywheel is semantic-release (single-package); replicating that buys nothing. So symphonize keeps dogfooding release-please and ships it as the monorepo option.

## Relationship to #109

Supersedes #109 (`plan/parameterize-init-release-tool`) — same section, but #109 defaulted to release-please and was 59 commits behind main, colliding with the since-evolved `§spec:reusable-ci`/`§spec:scaffold-freshness`. **#109 can be closed in favor of this.**

## Scope

SPEC.md + ROADMAP.md only. Implementation (template dirs, init prompt, re-run detection, `/clean` checks) is `/conduct:next` work.