### PR TITLE
docs(requirements): mandate trunk-based/GitHub Flow, exclude GitFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ without them.
   change flows through a feature branch and a PR with CI.
 - **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/)** —
   CHANGELOG.md format. `[Unreleased]` section always present.
+- **Trunk-based development / [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow)** —
+  one integration trunk (the repo's default branch); short-lived
+  feature branches merge back. Not a GitFlow or GitLab-Flow tool: no
+  long-lived `develop`/`staging` branches or merge-forward cascade.
 - **Feature branches per unit of work** — `/next` creates worktree
   branches, `/clean` prunes them. No long-lived branches.
 - **`gh` CLI as the Git-ops interface** — authenticated `gh` handles

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ without them.
   change flows through a feature branch and a PR with CI.
 - **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/)** —
   CHANGELOG.md format. `[Unreleased]` section always present.
-- **Trunk-based development / [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow)** —
+- **[Trunk-based development](https://trunkbaseddevelopment.com/) / [GitHub Flow](http://scottchacon.com/2011/08/31/github-flow.html)** —
   one integration trunk (the repo's default branch); short-lived
   feature branches merge back. Not a GitFlow or GitLab-Flow tool: no
   long-lived `develop`/`staging` branches or merge-forward cascade.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -120,6 +120,18 @@ not an active requirement.
   feature, feedback) guide submitters to provide actionable detail
   at filing time, reducing triage effort. `/feedback` handles the
   Claude Code side; templates handle the GitHub web UI side.
+- **Trunk-based / GitHub Flow only** — symphonize works on a single
+  integration trunk (the repository's default branch,
+  §spec:integration-ref): short-lived feature branches fork from it and
+  merge back. It is not a GitFlow or GitLab-Flow tool — it does not
+  support long-lived `develop`/`staging`/`production` branches or the
+  merge-forward promotion cascade. Modern promotion (dev→staging→prod)
+  moves one immutable artifact through gated environments rather than
+  merging code across long-lived branches, so that cascade is out of
+  symphonize's grain. A non-`main` trunk works by setting that branch as
+  the repository default. Teams committed to GitFlow/GitLab Flow should
+  not adopt symphonize expecting it to honor those branch topologies.
+  (§req:modular-adoption)
 
 ## Priorities §req:priorities
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1508,6 +1508,11 @@ trunk from the repository's default branch — rather than introducing a
 configuration file — keeps the "no state beyond governance documents" constraint
 intact while removing the wrong-branch failure for every non-`main` project.
 
+The single trunk is a deliberate scope boundary, not just an implementation
+choice: symphonize is trunk-based / GitHub Flow only and does not model
+GitFlow/GitLab-Flow long-lived branches or the merge-forward cascade
+(§req:constraints).
+
 ### Scope
 
 The hardcoded trunk spans conduct (`next.md`, `review.md`, `clean.md`,


### PR DESCRIPTION
## What

Makes trunk-based development / GitHub Flow a **MUST** constraint and states symphonize's supported-workflow scope explicitly, so GitFlow / GitLab-Flow users self-select out before adopting.

## Why

symphonize models a **single integration trunk** — the repository's resolved default branch (`§spec:integration-ref`, shipped 0.2.2). Short-lived feature branches fork from it and merge back. There is no concept of an integration branch separate from the release branch, so GitFlow's `develop`/`release`/`hotfix` cascade and GitLab Flow's environment branches are out of grain. Modern promotion (dev→staging→prod) moves one immutable artifact through gated environments rather than merging code across long-lived branches.

A non-`main` trunk already works today: set that branch as the GitHub default and integration-ref resolves it.

## Changes

- **REQUIREMENTS.md** `§req:constraints` — new `Trunk-based / GitHub Flow only` MUST constraint with rationale, cross-referencing `§req:modular-adoption` and `§spec:integration-ref`.
- **README.md** Opinions — one-line scope note linking GitHub Flow.
- **SPEC.md** `§spec:integration-ref` — cross-ref back to the constraint, framing the single trunk as a deliberate scope boundary.

## Scope boundary preserved

This does **not** preclude a future optional base-branch override for one-off runs against a release/maintenance branch (e.g. `release/12.1`, versioned software with parallel supported lines). That is not GitFlow support and does not contradict this constraint.

## Verification

- `npx markdownlint-cli2` — 0 errors.
- All `§`-references resolve to existing slugs (`§req:constraints`, `§spec:integration-ref`, `§req:modular-adoption`).