### PR TITLE
docs(governance): replace deprecated must with IEEE-compliant wording

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -213,7 +213,7 @@ Success looks like:
   real state and what the documents say stays small.
 - A governance change meets far less friction than a code change, and
   rarely produces a PR that conflicts on GitHub.
-- The effort a change must clear is **proportional to its nature** — an
+- The effort required of a change is **proportional to its nature** — an
   interpreted document is judged by whether it parses and reads
   coherently, not held to the checks compiled code requires.
   §req:quality-attributes

--- a/SPEC.md
+++ b/SPEC.md
@@ -302,7 +302,7 @@ flow into REQUIREMENTS.md as prose.
   Expensive, Mandatory, Growing, Urgent, Distant) prompt the user
   to articulate *why* the problem matters.
 - **Validation (Phase 2):** ICE framework (Impact, Confidence,
-  Ease) surfaces priority tradeoffs beyond binary must/nice-to-have.
+  Ease) surfaces priority tradeoffs beyond a binary essential/nice-to-have split.
 
 **Why frameworks as prompts:** users describe *what* they want
 without explaining *why*. Framework-derived questions produce
@@ -692,7 +692,7 @@ Spending the agent spawns on prose is noise. §req:quality-attributes
 - **Run the gate inside the batch agent.** Rejected: `/security-review` (a
   reporter) can end a sub-agent's turn before delivery, so gates co-locate at the
   dispatch layer where a turn-end is survivable. `/simplify` alone would survive
-  in-batch, but splitting the gates buys nothing — the batch must hand back for the
+  in-batch, but splitting the gates buys nothing — the batch hands back for the
   reporter gate regardless (§spec:batch-agent-leaf).
 
 **Tradeoffs accepted:**
@@ -700,7 +700,7 @@ Spending the agent spawns on prose is noise. §req:quality-attributes
 - Parallel agent spawns per batch, charged against the dispatch layer's
   token budget.
 - CI runs again after the gate mutates the branch.
-- Simplify may propose fixes the dispatch layer must revert, costing review
+- Simplify may propose fixes the dispatch layer then reverts, costing review
   time. Bounded by running simplify once.
 
 ## Batch agent is a fan-out leaf §spec:batch-agent-leaf


### PR DESCRIPTION
Vale's `Requirements.MustDeprecated` rule errors on `must`. Four occurrences in SPEC.md and REQUIREMENTS.md violate it — local Vale reports them while CI stays green.

Two were genuine modals, rewritten to the indicative. Two were false positives where `must` named a prioritization category rather than an obligation; swapping those to `shall` would have corrupted the meaning, so they were reworded to drop the token.

- SPEC.md — "binary must/nice-to-have" -> "a binary essential/nice-to-have split"
- SPEC.md — "the batch must hand back" -> "the batch hands back"
- SPEC.md — "the dispatch layer must revert" -> "the dispatch layer then reverts"
- REQUIREMENTS.md — "the effort a change must clear" -> "the effort required of a change"

`vale SPEC.md REQUIREMENTS.md` now reports 0 errors, 0 warnings. markdownlint unchanged.

Merge before any vale-action upgrade that makes push-triggered runs enforce, or main goes red.
