### PR TITLE
ci: bump markdownlint-cli2-action to v24 for Node 24

### DIFF
--- a/.github/workflows/governance-lint.yml
+++ b/.github/workflows/governance-lint.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fail_on_error: true
 
-      - uses: DavidAnson/markdownlint-cli2-action@v19
+      - uses: DavidAnson/markdownlint-cli2-action@v24
         with:
           globs: |
             **/SPEC.md


### PR DESCRIPTION
GitHub removes Node 20 from Actions runners on 2026-09-16. `DavidAnson/markdownlint-cli2-action@v19` declares `using: node20`; `@v24` declares `node24`.

Input surface is identical across the jump (`config`, `fix`, `globs`, `separator`), so this is a runtime-only change. The underlying tool moves from markdownlint-cli2 0.17.2 to 0.23.2; the repo's governance files were linted against 0.23.2 locally first and report 0 issues, so the newer core surfaces nothing new here.

Every other action in the repo already runs node24, including `vale-cli/vale-action@v2` — the CI annotation naming it was from a run predating the v2 tag moving. No other bumps needed.

Consumers of the reusable `governance-lint.yml` inherit this fix.
