### PR TITLE
fix(notation): scaffolded pre-commit hook blocks every governance commit

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -102,6 +102,14 @@ activation is per-checkout. Consumers opt in by running
 `/notation:init` — upstream repos do not push hooks on
 contributors. CI is the backstop.
 
+The hook resolves its linter through the common version-manager locations
+before giving up, because git hooks inherit no interactive shell and a bare
+invocation misses nvm, fnm, and volta shims. When no toolchain is reachable
+it reports the skip and exits clean. **Why degrade rather than fail:** a
+governance repo need not carry the linter's runtime at all, and CI runs the
+same check unconditionally — blocking the commit would trade a real
+contribution for a check that was going to run anyway.
+
 The command is idempotent: it skips files that already exist and
 warns rather than overwrites.
 

--- a/plugins/notation/commands/init.md
+++ b/plugins/notation/commands/init.md
@@ -184,9 +184,37 @@ set -euo pipefail
 
 # Only lint when governance files are staged
 staged=$(git diff --cached --name-only)
-if echo "$staged" | grep -qE '^(SPEC|ROADMAP|README)\.md$'; then
-  npx markdownlint-cli2 SPEC.md ROADMAP.md README.md
+if ! echo "$staged" | grep -qE '^(SPEC|ROADMAP|README)\.md$'; then
+  exit 0
 fi
+
+# Git hooks run with a minimal PATH and do not inherit an interactive shell,
+# so version-manager shims (nvm, fnm, volta) are absent and a bare `npx`
+# fails even when node is installed. Look in the usual places.
+if ! command -v npx >/dev/null 2>&1; then
+  for dir in \
+    "$HOME"/.nvm/versions/node/*/bin \
+    "$HOME"/.volta/bin \
+    "$HOME"/.local/share/fnm/node-versions/*/installation/bin \
+    /opt/homebrew/bin \
+    /usr/local/bin
+  do
+    if [ -x "${dir}/npx" ]; then
+      PATH="${dir}:${PATH}"
+      export PATH
+      break
+    fi
+  done
+fi
+
+# No node toolchain reachable: skip rather than block. CI runs the same
+# check and is the authority.
+if ! command -v npx >/dev/null 2>&1; then
+  echo "pre-commit: npx not found, skipping markdownlint (CI still enforces it)" >&2
+  exit 0
+fi
+
+npx markdownlint-cli2 SPEC.md ROADMAP.md README.md
 ```
 
 Then activate hooks for this checkout:


### PR DESCRIPTION
The `pre-commit` hook scaffolded by `/notation:init` calls a bare `npx`. Git hooks run with a minimal PATH and do not inherit an interactive shell, so version-manager shims (nvm, fnm, volta) are absent and `npx` exits 127 even when node is installed.

Every adopter gets a hook that blocks **all** commits touching SPEC.md, ROADMAP.md, or README.md:

```
.githooks/pre-commit: line 7: npx: command not found
```

Found while adopting notation in a downstream repo — activating `core.hooksPath` immediately made the repo uncommittable for governance files, with no escape hatch where a hook-bypass flag is itself denied by policy.

## The fix

Resolve `npx` through the common version-manager locations, then **skip with a notice rather than fail** when no toolchain is reachable.

Degrading is what the contract already asks for. §spec:governance-lint says the hook "never blocks a commit on an absent optional tool; CI is the authoritative backstop" — but that section is `not started`, so the shipped hook's behavior was unspecified. The first commit states it in §spec:project-scaffolding, which is `complete` and describes what actually runs today.

The rationale matters beyond the PATH bug: a governance repo need not carry the linter's runtime at all. A Python or Rust project adopting notation has no reason to install node, and failing their commits for a check CI runs unconditionally trades a real contribution for nothing.

## Verification

The script was extracted from the command file and exercised directly:

| case | before | after |
|---|---|---|
| no governance files staged | exit 0 | exit 0 |
| staged, `npx` reachable | lint runs | lint runs, 0 issues |
| staged, no node anywhere | **exit 127, commit blocked** | notice + exit 0 |

Case 2 also confirms the fallback search works: `npx` was found under nvm without being on PATH.

`vale` 0 errors, `markdownlint-cli2` 0 issues, `assemble-fragments.sh` reports no drift.

## Note for #115

This touches only the current `npx markdownlint-cli2` form. When the bundled `governance-lint` script lands, the hook body is replaced wholesale — the PATH-resolution problem and the degrade-don't-block rule will both still apply to whatever invokes that script.
