### PR TITLE
ci: upgrade vale-action to v3 so prose linting can actually fail

### DIFF
--- a/.github/workflows/governance-lint.yml
+++ b/.github/workflows/governance-lint.yml
@@ -19,9 +19,12 @@ jobs:
 
       - name: Run Vale prose linter
         if: hashFiles('.vale.ini') != ''
-        uses: vale-cli/vale-action@v2
+        uses: vale-cli/vale-action@v3
         with:
           fail_on_error: true
+          # Report every finding in the linted files, not only lines the
+          # current diff touches, so CI matches a local `vale` run.
+          filter_mode: nofilter
 
       - uses: DavidAnson/markdownlint-cli2-action@v24
         with:

--- a/SPEC.md
+++ b/SPEC.md
@@ -390,6 +390,16 @@ that drifts toward vague, passive, non-testable language.
 Mechanical enforcement catches `the system will...` (deprecated)
 and `it should be noted that...` (filler) before review.
 
+CI evaluates the whole file rather than the diff, and a violation
+fails the job wherever it sits — including lines the current change
+never touched. A push to the trunk is checked on the same terms as a
+pull request. **Why:** a rule added after a document was written
+never meets the existing text under diff-scoped reporting, and a
+branch cut before the rule existed lands violations that stay
+invisible from then on. Document-wide reach in the style earns
+nothing unless enforcement has the same reach; local `vale` and CI
+otherwise disagree about a file they both claim to check.
+
 ## Requirements frameworks §spec:requirements-frameworks
 *Status: complete*
 


### PR DESCRIPTION
Vale currently cannot fail a push to the trunk, and on pull requests it only ever sees lines inside the diff. Two independent behaviours combine:

- `vale-action@v2` on a `push` event with a `github-pr-*` reporter reports nothing and exits `0` — the reviewdog build is not a pull request, so it no-ops.
- `filter_mode` defaults to `added`, so even on a PR only lines the change touched are reported.

Net effect: a violation entering through a branch cut before a rule existed stays invisible from then on, and `fail_on_error: true` never sees it.

## This is observed, not theoretical

A downstream repo adopting notation had a live `must` error sitting on its trunk while governance-lint reported **success** on that same commit:

```
SPEC.md:223:14  error  'must' is deprecated by IEEE. Use 'shall' for mandatory requirements.
```

It arrived via a branch cut before the Vale config landed, and merged after it. Local `vale` found it immediately; CI was green.

## The change

`vale-action@v3.0.0` — its headline breaking change is exactly this case: *"Workflows triggered on `push` using a `github-pr-*` reporter previously reported nothing (`this is not PullRequest build`, exit 0). They now lint, and can fail."*

`filter_mode: nofilter` closes the other half, so a local `vale SPEC.md REQUIREMENTS.md` and CI agree about a file they both claim to check.

`fail_on_error: true` is kept and its meaning improves under v3: it now fails on **errors only**, where v2 failed on a finding of any severity. `WillDeprecated` and `FillerPhrases` are warnings and stay non-blocking — which is what the style intends.

## Blast radius

Deliberately timed for when it is small. Every repo linted by this reusable workflow is clean right now:

- symphonize — `vale SPEC.md REQUIREMENTS.md` → 0 errors, 0 warnings (the four `must` occurrences were fixed in #193)
- the downstream adopter — fixed in its own PR

Turning on real enforcement later, against accumulated drift, costs strictly more.

## Relationship to other work

**§road:modal-verb-scope** is adjacent but separate. That workstream is about `/compose` commands generating narrative `must` that passes locally *because the local script skips Vale*. This PR is the CI half. Complementary.

**#115** (single-source governance-lint script) would eventually replace action-level configuration with a bundled script. It is `not started`; this is a two-line change that stops the bleeding meanwhile, and the parity requirement it encodes is the same one #115 exists to satisfy.

## Verification

`vale` 0 errors / 0 warnings, `markdownlint-cli2` 0 issues, slug grammar and SPEC status lines 0 errors, `assemble-fragments.sh` reports no drift. Workflow YAML parses and the step resolves to `vale-cli/vale-action@v3` with `{fail_on_error: true, filter_mode: nofilter}`.

The real proof is this PR's own governance-lint run: it exercises the new configuration against the full file set.
