### PR TITLE
feat: batch — parameterized release scaffolding in /notation:init

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
 version: 2
 updates:
   # Keep the GitHub Actions pinned in .github/workflows current. These
-  # workflow files are also the templates /notation:init copies into
-  # consuming repos, so keeping them fresh here keeps new scaffolds from
-  # shipping stale action versions.
+  # workflow files are also the canonical source of the release-please
+  # scaffold templates (tools/assemble-fragments.sh copies them into
+  # plugins/notation/templates/), so keeping them fresh here keeps new
+  # scaffolds from shipping stale action versions.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -10,7 +10,13 @@ permissions:
 
 jobs:
   auto-merge:
-    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    # pull_request_target runs in the base-repo context with full secret
+    # access, so the label alone is not a sufficient gate — anyone who can
+    # label a fork PR would otherwise reach the App token and auto-merge it.
+    # Release PRs are same-repo branches; require that.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v3

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -9,6 +9,10 @@ permissions:
 
 jobs:
   update-major-tag:
+    # The adopter template (plugins/notation/templates/release-please/) is this
+    # workflow without the gate below, so it is hand-maintained rather than
+    # copied by tools/assemble-fragments.sh.
+    #
     # Only the notation release moves a floating major tag. Adopters pin the
     # reusable governance-lint.yml workflow cross-repo via
     # `@notation--v<major>` (§spec:plugin-packaging, §spec:notation-contract);

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -9,10 +9,6 @@ permissions:
 
 jobs:
   update-major-tag:
-    # The adopter template (plugins/notation/templates/release-please/) is this
-    # workflow without the gate below, so it is hand-maintained rather than
-    # copied by tools/assemble-fragments.sh.
-    #
     # Only the notation release moves a floating major tag. Adopters pin the
     # reusable governance-lint.yml workflow cross-repo via
     # `@notation--v<major>` (§spec:plugin-packaging, §spec:notation-contract);

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,33 +87,6 @@ is `fix: batch — <summary>`. Run a batch containing at least one
 and §spec:batch-delivery agree the delivered type is derived, not
 hardcoded. Governance-lint passes.
 
-## Parameterized release scaffolding §road:release-automation-scaffolding
-
-### Create per-tool scaffold templates §road:release-templates
-
-Add `templates/flywheel/` (`flywheel-pr.yml`, `flywheel-push.yml`,
-`.flywheel.yml`), move the existing release-please workflows into
-`templates/release-please/`, and define `templates/manual/` (no
-release-automation files), keeping symphonize's own `.github/workflows/*`
-as the dogfooded release-please source. §spec:release-automation-options
-§spec:reusable-ci
-
-### Tool selection in /notation:init §road:init-release-selection
-
-Add the release-automation prompt (flywheel default), copy from the chosen
-`templates/<tool>/`, and detect the existing choice from `.flywheel.yml` /
-`release-please-config.json` to skip the prompt on re-run, in
-`plugins/notation/commands/init.md`. Depends on §road:release-templates.
-§spec:release-automation-options
-
-**Verify:** In a fresh repo, run `/notation:init` and accept the default —
-confirm it scaffolds `.flywheel.yml` and the flywheel workflows and no
-release-please files. Run it again — confirm it detects flywheel and skips
-the prompt, scaffolding only missing files. In separate fresh repos, select
-release-please (confirm `release-please-config.json` + workflows) and manual
-(confirm no release-automation files, but CHANGELOG.md still carries
-`[Unreleased]`). Governance-lint passes.
-
 ## Release-aware clean checks §road:release-aware-clean
 
 ### Per-tool release check in /conduct:clean §road:clean-release-check
@@ -122,7 +95,7 @@ Detect the release tool from `.flywheel.yml` / `release-please-config.json`
 / neither and run the matching advisory check (flywheel eligibility, next
 release-please PR, or manual CHANGELOG/tag reminder) in
 `plugins/conduct/commands/clean.md`, mirroring the re-run detection signals
-in §road:init-release-selection. §spec:release-automation-options
+`/notation:init` already reads. §spec:release-automation-options
 
 **Verify:** Run `/conduct:clean` in a flywheel-scaffolded repo with
 unreleased commits — confirm it reports the commits are eligible for a

--- a/SPEC.md
+++ b/SPEC.md
@@ -220,7 +220,7 @@ decomposition (§spec:governance-schema); this freshness contract is
 notation's and moves with it. §req:modular-adoption
 
 ## Release automation options §spec:release-automation-options
-*Status: not started*
+*Status: in progress*
 
 `/notation:init` lets the adopter choose how conventional commits become
 versioned releases. The supported options are **flywheel** (default),

--- a/SPEC.md
+++ b/SPEC.md
@@ -188,10 +188,10 @@ a consumer holds a point-in-time snapshot that does not self-update.
   failing on drift. If the source rots, every new scaffold ships stale action
   versions — "init-ing the past." Symphonize keeps the source current with
   Dependabot (`github-actions`), so a fresh scaffold ships current pins. Two
-  templates fall outside that copy: `update-major-tag.yml`, which symphonize
-  gates to its notation release and the adopter form does not, and the
-  flywheel set, which symphonize does not run. Both are hand-maintained and
-  pin floating majors, so they self-update on the action side.
+  template sets fall outside the copy and so outside Dependabot's reach:
+  `update-major-tag.yml`, which symphonize gates to its notation release and
+  the adopter form does not, and the flywheel set, which symphonize does not
+  run. Both are hand-maintained; their action pins need review by hand.
 - **Copy freshness — the consumer's concern.** A consumer's copied
   workflows are theirs to mutate and theirs to keep current. `init`
   scaffolds a `.github/dependabot.yml` (`github-actions`) into the consumer

--- a/SPEC.md
+++ b/SPEC.md
@@ -130,8 +130,13 @@ reusable GitHub Actions workflows that target projects reference via
 the release-please template set — symphonize's own dogfooded workflows
 (§spec:dogfooding), and what `/notation:init` copies when an adopter
 selects release-please. Flywheel and manual adopters scaffold a different
-file set, organized under `templates/<tool>/`
-(§spec:release-automation-options).
+file set (§spec:release-automation-options).
+
+Every scaffold template lives under `plugins/notation/templates/<tool>/`,
+one directory per release-automation option. Plugin isolation forces the
+location: an installed plugin reads only its own directory
+(§spec:plugin-packaging), so `init` cannot reach a repository-root
+`templates/`.
 
 ### governance-lint.yml
 
@@ -177,12 +182,16 @@ chosen tool's release workflows (§spec:release-automation-options) are
 copied verbatim because each needs project-specific config and tokens, so
 a consumer holds a point-in-time snapshot that does not self-update.
 
-- **Source freshness — symphonize's concern.** The copied templates'
-  source is symphonize's own `.github/workflows/*`, and the plugin bundle
-  init copies from is built from it. If the source rots, every new scaffold
-  ships stale action versions — "init-ing the past." Symphonize keeps the
-  source current with Dependabot (`github-actions`), so a fresh scaffold
-  ships current pins.
+- **Source freshness — symphonize's concern.** The release-please templates'
+  source is symphonize's own `.github/workflows/*`, and
+  `tools/assemble-fragments.sh` copies them into the notation plugin, with CI
+  failing on drift. If the source rots, every new scaffold ships stale action
+  versions — "init-ing the past." Symphonize keeps the source current with
+  Dependabot (`github-actions`), so a fresh scaffold ships current pins. Two
+  templates fall outside that copy: `update-major-tag.yml`, which symphonize
+  gates to its notation release and the adopter form does not, and the
+  flywheel set, which symphonize does not run. Both are hand-maintained and
+  pin floating majors, so they self-update on the action side.
 - **Copy freshness — the consumer's concern.** A consumer's copied
   workflows are theirs to mutate and theirs to keep current. `init`
   scaffolds a `.github/dependabot.yml` (`github-actions`) into the consumer

--- a/plugins/notation/commands/init.md
+++ b/plugins/notation/commands/init.md
@@ -164,6 +164,22 @@ Create under `.github/workflows/`:
   pre-1.0, so the adopter-facing major ref is `notation--v0` (not `v1`).
   `update-major-tag.yml` moves this tag forward on each notation release.
 
+Also create `.github/dependabot.yml`. The scaffolded workflows are the
+project's copies to maintain, and their action pins go stale; Dependabot
+is what keeps them current:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+If the file exists, add the `github-actions` entry only when it is
+missing; leave every other entry alone.
+
 ### Release automation
 
 Each option's templates live at
@@ -216,8 +232,14 @@ Report the remaining setup as manual steps — they need repo admin and
 3. Grant the App a branch-protection bypass on managed branches —
    without it, flywheel cannot push its release commit or tag.
 
-Point the adopter at <https://github.com/point-source/flywheel> for the
-current setup script.
+State the trust this buys: flywheel is a third-party action, and steps 1
+and 3 hand it a private key plus the standing to write the default branch
+unreviewed. The templates pin it by commit SHA so its repository cannot
+repoint that credential at new code; review each bump.
+
+<https://github.com/point-source/flywheel> carries a setup script that
+automates the three steps. Say it exists, say it provisions the App, and
+tell the adopter to read it before running it — do not run it here.
 
 #### release-please
 
@@ -305,7 +327,8 @@ hooks.
    If it does, print `skip: <path> (already exists)` and move on.
 4. Create any missing governance files at the governance root.
 5. If CWD is the repo root, also scaffold CI workflows and hooks:
-   a. Create `.github/workflows/governance-lint.yml`.
+   a. Create `.github/workflows/governance-lint.yml` and
+      `.github/dependabot.yml`.
    b. Resolve the release-automation tool per § Release automation and
       copy its templates.
    c. Create `.githooks/pre-commit` and make it executable.

--- a/plugins/notation/commands/init.md
+++ b/plugins/notation/commands/init.md
@@ -226,8 +226,12 @@ Report the remaining setup as manual steps — they need repo admin and
 
 1. Install a GitHub App with Contents, Pull requests, Issues, and
    Checks read/write, then store its id as the repository **variable**
-   `FLYWHEEL_GH_APP_ID` and its private key as the **secret**
-   `FLYWHEEL_GH_APP_PRIVATE_KEY`.
+   `FLYWHEEL_GH_APP_ID` and its private key as the **Actions secret**
+   `FLYWHEEL_GH_APP_PRIVATE_KEY`. Registering that key in the
+   **Dependabot** secret store as well is a separate decision: it is what
+   lets Dependabot's `chore(deps)` PRs auto-merge unreviewed, including
+   bumps to the flywheel pin itself. Leave it unregistered to keep the
+   review gate.
 2. Enable "Allow auto-merge" in repository settings.
 3. Grant the App a branch-protection bypass on managed branches —
    without it, flywheel cannot push its release commit or tag.

--- a/plugins/notation/commands/init.md
+++ b/plugins/notation/commands/init.md
@@ -166,10 +166,9 @@ Create under `.github/workflows/`:
 
 ### Release automation
 
-Which release-automation files to scaffold depends on the adopter's
-choice of tool. Each option has a template directory at
-`${CLAUDE_PLUGIN_ROOT}/templates/<tool>/`; copy its files verbatim.
-Like every other file, skip one that already exists.
+Each option's templates live at
+`${CLAUDE_PLUGIN_ROOT}/templates/<tool>/`. Copy the files its section
+below names, verbatim — nothing else in that directory is a template.
 
 #### Detect before prompting
 
@@ -182,8 +181,7 @@ Read repo state first and skip the prompt when it already answers:
 On a detected choice, print
 `detected release automation: <tool>` and scaffold only the missing
 files of that tool's set. Switching tools is not a prompt outcome —
-tell the adopter to remove the old config first. Do not migrate one
-tool's state to another.
+tell the adopter to remove the old config first.
 
 #### Prompt
 
@@ -228,12 +226,10 @@ Copy from `templates/release-please/`:
 - `release-please.yml`, `auto-merge-release.yml`,
   `update-major-tag.yml` → `.github/workflows/`.
 
-Then generate the two project-specific files, which have no template
-because their content is derived:
-
-- `release-please-config.json` and `.release-please-manifest.json`,
-  carrying the project's current version (read from `package.json`,
-  `pubspec.yaml`, `.claude-plugin/plugin.json`, or default to `0.1.0`).
+Then generate `release-please-config.json` and
+`.release-please-manifest.json` with the project's current version (read
+from `package.json`, `pubspec.yaml`, `.claude-plugin/plugin.json`, or
+default to `0.1.0`).
 
 The workflows authenticate through a GitHub App. Report as a manual
 step: store the App id as `RELEASE_BOT_APP_ID` and its private key as
@@ -310,9 +306,8 @@ hooks.
 4. Create any missing governance files at the governance root.
 5. If CWD is the repo root, also scaffold CI workflows and hooks:
    a. Create `.github/workflows/governance-lint.yml`.
-   b. Resolve the release-automation tool per § Release automation —
-      detect from repo state, otherwise prompt — then copy that
-      tool's template files.
+   b. Resolve the release-automation tool per § Release automation and
+      copy its templates.
    c. Create `.githooks/pre-commit` and make it executable.
    d. Run `git config core.hooksPath .githooks` to activate hooks.
 6. If CWD is not the repo root, skip CI workflows, release automation,

--- a/plugins/notation/commands/init.md
+++ b/plugins/notation/commands/init.md
@@ -164,15 +164,85 @@ Create under `.github/workflows/`:
   pre-1.0, so the adopter-facing major ref is `notation--v0` (not `v1`).
   `update-major-tag.yml` moves this tag forward on each notation release.
 
-- **release-please.yml** — copy from symphonize's template. Also
-  create `release-please-config.json` and
-  `.release-please-manifest.json` with the project's current version
-  (read from `package.json`, `pubspec.yaml`, `.claude-plugin/plugin.json`,
-  or default to `0.1.0`).
+### Release automation
 
-- **auto-merge-release.yml** — copy from symphonize's template.
+Which release-automation files to scaffold depends on the adopter's
+choice of tool. Each option has a template directory at
+`${CLAUDE_PLUGIN_ROOT}/templates/<tool>/`; copy its files verbatim.
+Like every other file, skip one that already exists.
 
-- **update-major-tag.yml** — copy from symphonize's template.
+#### Detect before prompting
+
+Read repo state first and skip the prompt when it already answers:
+
+- `.flywheel.yml` present → flywheel.
+- `release-please-config.json` present → release-please.
+- Neither → prompt.
+
+On a detected choice, print
+`detected release automation: <tool>` and scaffold only the missing
+files of that tool's set. Switching tools is not a prompt outcome —
+tell the adopter to remove the old config first. Do not migrate one
+tool's state to another.
+
+#### Prompt
+
+When nothing is detected, ask: "How should releases be cut from
+conventional commits?" Offer flywheel (default), release-please, and
+manual. Take flywheel when the adopter accepts the default or the run
+is unattended.
+
+- **flywheel** — per-PR auto-merge by commit type, release on push to
+  a managed branch. Fits single-package projects.
+- **release-please** — accumulates commits into a release PR. Fits
+  monorepos needing linked versions across packages.
+- **manual** — no release automation. Edit CHANGELOG.md and tag by
+  hand.
+
+#### flywheel
+
+Copy from `templates/flywheel/`:
+
+- `.flywheel.yml` → the repository root. If the repo's default branch
+  is not `main`, rename the branch entry to match.
+- `flywheel-pr.yml`, `flywheel-push.yml` → `.github/workflows/`.
+
+Report the remaining setup as manual steps — they need repo admin and
+`gh`, so do not run them:
+
+1. Install a GitHub App with Contents, Pull requests, Issues, and
+   Checks read/write, then store its id as the repository **variable**
+   `FLYWHEEL_GH_APP_ID` and its private key as the **secret**
+   `FLYWHEEL_GH_APP_PRIVATE_KEY`.
+2. Enable "Allow auto-merge" in repository settings.
+3. Grant the App a branch-protection bypass on managed branches —
+   without it, flywheel cannot push its release commit or tag.
+
+Point the adopter at <https://github.com/point-source/flywheel> for the
+current setup script.
+
+#### release-please
+
+Copy from `templates/release-please/`:
+
+- `release-please.yml`, `auto-merge-release.yml`,
+  `update-major-tag.yml` → `.github/workflows/`.
+
+Then generate the two project-specific files, which have no template
+because their content is derived:
+
+- `release-please-config.json` and `.release-please-manifest.json`,
+  carrying the project's current version (read from `package.json`,
+  `pubspec.yaml`, `.claude-plugin/plugin.json`, or default to `0.1.0`).
+
+The workflows authenticate through a GitHub App. Report as a manual
+step: store the App id as `RELEASE_BOT_APP_ID` and its private key as
+`RELEASE_BOT_PRIVATE_KEY`, both repository secrets.
+
+#### manual
+
+Scaffold no release-automation files. CHANGELOG.md still gets its
+`[Unreleased]` section from the governance-file step above.
 
 ### Git hooks
 
@@ -239,13 +309,17 @@ hooks.
    If it does, print `skip: <path> (already exists)` and move on.
 4. Create any missing governance files at the governance root.
 5. If CWD is the repo root, also scaffold CI workflows and hooks:
-   a. Create CI workflow files under `.github/workflows/`.
-   b. Create `.githooks/pre-commit` and make it executable.
-   c. Run `git config core.hooksPath .githooks` to activate hooks.
-6. If CWD is not the repo root, skip CI workflows and hooks with
-   a note.
+   a. Create `.github/workflows/governance-lint.yml`.
+   b. Resolve the release-automation tool per § Release automation —
+      detect from repo state, otherwise prompt — then copy that
+      tool's template files.
+   c. Create `.githooks/pre-commit` and make it executable.
+   d. Run `git config core.hooksPath .githooks` to activate hooks.
+6. If CWD is not the repo root, skip CI workflows, release automation,
+   and hooks with a note.
 7. Run `/notation:lint` to validate the result.
-8. Print a summary of created and skipped files.
+8. Print a summary of created and skipped files, the release-automation
+   tool used, and any manual setup steps it needs.
 
 Do NOT commit. Leave the files unstaged so the user can review
 and commit when ready.

--- a/plugins/notation/templates/flywheel/.flywheel.yml
+++ b/plugins/notation/templates/flywheel/.flywheel.yml
@@ -6,8 +6,6 @@
 # `feat` is deliberately absent so features gate on review.
 #
 # `!`-suffixed types are separate entries: `fix` does not imply `fix!`.
-# Recognized types: feat, fix, chore, refactor, perf, style, test, docs,
-# build, ci, revert.
 flywheel:
   streams:
     - name: main-line

--- a/plugins/notation/templates/flywheel/.flywheel.yml
+++ b/plugins/notation/templates/flywheel/.flywheel.yml
@@ -5,6 +5,11 @@
 # every other type gates on a human. Tune the list to the project's taste —
 # `feat` is deliberately absent so features gate on review.
 #
+# `chore` covers dependency bumps, so listing it means Dependabot's updates
+# can land unreviewed. Flywheel gates that separately: those PRs auto-merge
+# only once the App private key is also registered in the Dependabot secret
+# store. Withhold that registration, or drop `chore`, to keep the review gate.
+#
 # `!`-suffixed types are separate entries: `fix` does not imply `fix!`.
 flywheel:
   streams:

--- a/plugins/notation/templates/flywheel/.flywheel.yml
+++ b/plugins/notation/templates/flywheel/.flywheel.yml
@@ -1,0 +1,17 @@
+# Flywheel release configuration — single-stream starting point.
+#
+# `release: production` cuts a release on every push to the managed branch.
+# `auto_merge` lists the conventional-commit types that merge without review;
+# every other type gates on a human. Tune the list to the project's taste —
+# `feat` is deliberately absent so features gate on review.
+#
+# `!`-suffixed types are separate entries: `fix` does not imply `fix!`.
+# Recognized types: feat, fix, chore, refactor, perf, style, test, docs,
+# build, ci, revert.
+flywheel:
+  streams:
+    - name: main-line
+      branches:
+        - name: main
+          release: production
+          auto_merge: [fix, chore, docs]

--- a/plugins/notation/templates/flywheel/flywheel-pr.yml
+++ b/plugins/notation/templates/flywheel/flywheel-pr.yml
@@ -25,7 +25,10 @@ jobs:
       checks: write
     runs-on: ubuntu-latest
     steps:
-      - uses: point-source/flywheel@v2
+      # SHA-pinned, not @v2: this action receives a GitHub App private key,
+      # and a floating tag lets its repository repoint that credential at new
+      # code without review. Bump the pin deliberately.
+      - uses: point-source/flywheel@59758d1940ebe054ce9fdd4b7a7dc79a0cf235e0 # v2.1.0
         with:
           event: pull_request
           app-id: ${{ vars.FLYWHEEL_GH_APP_ID }}

--- a/plugins/notation/templates/flywheel/flywheel-pr.yml
+++ b/plugins/notation/templates/flywheel/flywheel-pr.yml
@@ -1,0 +1,32 @@
+name: Flywheel — PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+
+concurrency:
+  group: flywheel-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  conduct:
+    # Only run on 'edited' events when a human triggered the edit. Bot-driven
+    # edits (the Flywheel App rewriting titles/bodies, push-flow upserting
+    # promotion PR bodies) would otherwise flap conduct <-> push-flow writes on
+    # every promotion-source push.
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'edited' || github.event.sender.type == 'User')
+    # The degraded empty-key path (Dependabot PRs, where the App key is absent)
+    # posts the conventional-commit check with the built-in token, so the token
+    # needs checks:write.
+    permissions:
+      contents: read
+      checks: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: point-source/flywheel@v2
+        with:
+          event: pull_request
+          app-id: ${{ vars.FLYWHEEL_GH_APP_ID }}
+          app-private-key: ${{ secrets.FLYWHEEL_GH_APP_PRIVATE_KEY }}

--- a/plugins/notation/templates/flywheel/flywheel-push.yml
+++ b/plugins/notation/templates/flywheel/flywheel-push.yml
@@ -1,0 +1,19 @@
+name: Flywheel — Push
+
+on:
+  push:
+    branches: ["**"]
+
+concurrency:
+  group: flywheel-push-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: point-source/flywheel@v2
+        with:
+          event: push
+          app-id: ${{ vars.FLYWHEEL_GH_APP_ID }}
+          app-private-key: ${{ secrets.FLYWHEEL_GH_APP_PRIVATE_KEY }}

--- a/plugins/notation/templates/flywheel/flywheel-push.yml
+++ b/plugins/notation/templates/flywheel/flywheel-push.yml
@@ -10,9 +10,17 @@ concurrency:
 
 jobs:
   release:
+    # Flywheel mints its own App installation token for every write, so the
+    # built-in token needs read only. Without this block the job inherits the
+    # repository default, which on older repos is write on everything.
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: point-source/flywheel@v2
+      # SHA-pinned, not @v2: this action receives a GitHub App private key,
+      # and a floating tag lets its repository repoint that credential at new
+      # code without review. Bump the pin deliberately.
+      - uses: point-source/flywheel@59758d1940ebe054ce9fdd4b7a7dc79a0cf235e0 # v2.1.0
         with:
           event: push
           app-id: ${{ vars.FLYWHEEL_GH_APP_ID }}

--- a/plugins/notation/templates/manual/README.md
+++ b/plugins/notation/templates/manual/README.md
@@ -1,0 +1,9 @@
+# Manual release template
+
+Empty by design. The `manual` option scaffolds no release-automation
+files — no workflow, no config, no manifest. `/notation:init` still
+creates CHANGELOG.md with its `[Unreleased]` section; the adopter
+edits it and tags releases by hand.
+
+This directory exists so the three release-automation options share one
+`templates/<tool>/` shape. See SPEC.md §spec:release-automation-options.

--- a/plugins/notation/templates/manual/README.md
+++ b/plugins/notation/templates/manual/README.md
@@ -1,9 +1,9 @@
 # Manual release template
 
-Empty by design. The `manual` option scaffolds no release-automation
-files — no workflow, no config, no manifest. `/notation:init` still
-creates CHANGELOG.md with its `[Unreleased]` section; the adopter
-edits it and tags releases by hand.
+No templates by design. The `manual` option scaffolds no
+release-automation files — no workflow, no config, no manifest.
+`/notation:init` still creates CHANGELOG.md with its `[Unreleased]`
+section; the adopter edits it and tags releases by hand.
 
-This directory exists so the three release-automation options share one
-`templates/<tool>/` shape. See SPEC.md §spec:release-automation-options.
+This file documents the empty set. It is not a template; do not copy it
+into an adopter repo.

--- a/plugins/notation/templates/release-please/auto-merge-release.yml
+++ b/plugins/notation/templates/release-please/auto-merge-release.yml
@@ -1,0 +1,25 @@
+name: Auto-merge Release PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/plugins/notation/templates/release-please/auto-merge-release.yml
+++ b/plugins/notation/templates/release-please/auto-merge-release.yml
@@ -10,7 +10,13 @@ permissions:
 
 jobs:
   auto-merge:
-    if: contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    # pull_request_target runs in the base-repo context with full secret
+    # access, so the label alone is not a sufficient gate — anyone who can
+    # label a fork PR would otherwise reach the App token and auto-merge it.
+    # Release PRs are same-repo branches; require that.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v3

--- a/plugins/notation/templates/release-please/release-please.yml
+++ b/plugins/notation/templates/release-please/release-please.yml
@@ -1,0 +1,26 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@v5
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          token: ${{ steps.app-token.outputs.token }}

--- a/plugins/notation/templates/release-please/update-major-tag.yml
+++ b/plugins/notation/templates/release-please/update-major-tag.yml
@@ -13,6 +13,12 @@ permissions:
 
 jobs:
   update-major-tag:
+    # Prereleases and non-`v` tags do not move the floating major. Force-moving
+    # `v<major>` onto an RC would silently ship prerelease code to everyone
+    # pinned at `@v<major>`.
+    if: >-
+      github.event.release.prerelease == false &&
+      startsWith(github.ref_name, 'v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -22,6 +28,14 @@ jobs:
           # GITHUB_REF_NAME is the released tag, e.g. v1.2.0. Strip at the
           # first '.' to get the floating major, e.g. v1.
           version="${GITHUB_REF_NAME}"
+
+          # Reject any other shape. A tag with no '.' would yield
+          # major == version and force-push a release tag over itself.
+          if ! printf '%s' "$version" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::notice::${version} is not vMAJOR.MINOR.PATCH — not moving a floating tag"
+            exit 0
+          fi
+
           major="${version%%.*}"
 
           git config user.name "github-actions[bot]"

--- a/plugins/notation/templates/release-please/update-major-tag.yml
+++ b/plugins/notation/templates/release-please/update-major-tag.yml
@@ -1,7 +1,7 @@
-# Ungated form of symphonize's own .github/workflows/update-major-tag.yml.
+# Adopter form of symphonize's own .github/workflows/update-major-tag.yml.
 # Symphonize gates the job to its notation release; an adopter publishing one
-# version line needs no gate. Hand-maintained — not a byte copy, so
-# tools/assemble-fragments.sh does not sync it.
+# version line gates on tag shape instead. Hand-maintained — not a byte copy,
+# so tools/assemble-fragments.sh does not sync it.
 name: Update Major Version Tag
 
 on:

--- a/plugins/notation/templates/release-please/update-major-tag.yml
+++ b/plugins/notation/templates/release-please/update-major-tag.yml
@@ -1,0 +1,30 @@
+# Ungated form of symphonize's own .github/workflows/update-major-tag.yml.
+# Symphonize gates the job to its notation release; an adopter publishing one
+# version line needs no gate. Hand-maintained — not a byte copy, so
+# tools/assemble-fragments.sh does not sync it.
+name: Update Major Version Tag
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-major-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Move floating major tag
+        run: |
+          # GITHUB_REF_NAME is the released tag, e.g. v1.2.0. Strip at the
+          # first '.' to get the floating major, e.g. v1.
+          version="${GITHUB_REF_NAME}"
+          major="${version%%.*}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa "$major" -m "Update $major to $version"
+          git push origin "$major" --force

--- a/tools/assemble-fragments.sh
+++ b/tools/assemble-fragments.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-# Assemble canonical fragments into consuming command files.
+# Assemble canonical fragments and template copies into the plugins.
 #
 # Cross-plugin fragment assembly (SPEC §spec:plugin-packaging): installed
 # plugins are copied into ~/.claude/plugins/cache/ and cannot read files
 # outside their own directory, so shared content must physically live inside
 # each plugin. Hand-duplication drifts; this script keeps one canonical
 # source and writes it into every consumer between marker comments.
+#
+# The same isolation applies to the release-please scaffold templates
+# (SPEC §spec:scaffold-freshness): their canonical source is symphonize's own
+# dogfooded .github/workflows/*, which Dependabot keeps current, and the
+# notation plugin ships a copy that /notation:init reads. COPIES below syncs
+# whole files; CONSUMERS syncs marked regions.
 #
 # Idempotent: running it when everything is in sync produces no changes.
 # CI runs it then `git diff --exit-code` to fail on drift (see
@@ -31,6 +37,15 @@ CONSUMERS=(
   "governance-root|plugins/conduct/commands/next.md"
   "governance-root|plugins/notation/commands/lint.md"
   "governance-root|plugins/conduct/commands/clean.md"
+)
+
+# Whole-file copy registry: "canonical/source|plugin/destination".
+# Only workflows an adopter can use verbatim belong here. The templates'
+# update-major-tag.yml is deliberately absent: symphonize's own copy gates the
+# job to its notation release, so the adopter template is hand-maintained.
+COPIES=(
+  ".github/workflows/release-please.yml|plugins/notation/templates/release-please/release-please.yml"
+  ".github/workflows/auto-merge-release.yml|plugins/notation/templates/release-please/auto-merge-release.yml"
 )
 
 # assemble FRAGMENT_NAME TARGET_FILE
@@ -85,10 +100,34 @@ assemble() {
   echo "assembled ${fragment_name} -> ${target_rel}"
 }
 
+# copy_template SOURCE TARGET
+# Copies a canonical workflow verbatim into its plugin template slot.
+copy_template() {
+  local source_rel="$1"
+  local target_rel="$2"
+  local source="${REPO_ROOT}/${source_rel}"
+  local target="${REPO_ROOT}/${target_rel}"
+
+  if [ ! -f "$source" ]; then
+    echo "error: missing canonical source: ${source}" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname -- "$target")"
+  cp "$source" "$target"
+  echo "copied ${source_rel} -> ${target_rel}"
+}
+
 for entry in "${CONSUMERS[@]}"; do
   fragment_name="${entry%%|*}"
   target_rel="${entry#*|}"
   assemble "$fragment_name" "$target_rel"
+done
+
+for entry in "${COPIES[@]}"; do
+  source_rel="${entry%%|*}"
+  target_rel="${entry#*|}"
+  copy_template "$source_rel" "$target_rel"
 done
 
 echo "done"

--- a/tools/assemble-fragments.sh
+++ b/tools/assemble-fragments.sh
@@ -7,11 +7,9 @@
 # each plugin. Hand-duplication drifts; this script keeps one canonical
 # source and writes it into every consumer between marker comments.
 #
-# The same isolation applies to the release-please scaffold templates
-# (SPEC §spec:scaffold-freshness): their canonical source is symphonize's own
-# dogfooded .github/workflows/*, which Dependabot keeps current, and the
-# notation plugin ships a copy that /notation:init reads. COPIES below syncs
-# whole files; CONSUMERS syncs marked regions.
+# CONSUMERS syncs marked regions; COPIES syncs whole files — the
+# release-please scaffold templates, whose canonical source is symphonize's
+# own dogfooded .github/workflows/* (SPEC §spec:scaffold-freshness).
 #
 # Idempotent: running it when everything is in sync produces no changes.
 # CI runs it then `git diff --exit-code` to fail on drift (see
@@ -40,9 +38,8 @@ CONSUMERS=(
 )
 
 # Whole-file copy registry: "canonical/source|plugin/destination".
-# Only workflows an adopter can use verbatim belong here. The templates'
-# update-major-tag.yml is deliberately absent: symphonize's own copy gates the
-# job to its notation release, so the adopter template is hand-maintained.
+# Only workflows an adopter can use verbatim belong here; the template
+# directory documents the exceptions.
 COPIES=(
   ".github/workflows/release-please.yml|plugins/notation/templates/release-please/release-please.yml"
   ".github/workflows/auto-merge-release.yml|plugins/notation/templates/release-please/auto-merge-release.yml"
@@ -113,8 +110,7 @@ copy_template() {
     exit 1
   fi
 
-  mkdir -p "$(dirname -- "$target")"
-  cp "$source" "$target"
+  cp -- "$source" "$target"
   echo "copied ${source_rel} -> ${target_rel}"
 }
 


### PR DESCRIPTION
Parameterizes release scaffolding: `/notation:init` now asks how releases get
cut, and copies from a per-tool template directory. Vertical slice — the
templates only count because `init.md` selects and copies from them.

## Workstreams

- **§road:release-templates** — `feat(notation): add per-tool release scaffold
  templates`. Adds `plugins/notation/templates/{flywheel,release-please,manual}/`.
  `tools/assemble-fragments.sh` gains a whole-file copy registry so the two
  verbatim release-please workflows stay synced from `.github/workflows/`,
  keeping symphonize's own dogfooded copies the canonical source and putting the
  templates in Dependabot's reach. CI's existing drift job covers it.
- **§road:init-release-selection** — `feat(notation): select release automation
  in /notation:init`. Adds the prompt (flywheel default), the per-tool copy
  lists, and re-run detection from `.flywheel.yml` / `release-please-config.json`.

Both bullets removed from ROADMAP.md; §spec:release-automation-options moves to
*in progress* (§road:clean-release-check still open).

## Why the templates live under `plugins/notation/`

ROADMAP said `templates/<tool>/`. An installed plugin is copied into
`~/.claude/plugins/cache/` and reads only its own directory
(§spec:plugin-packaging), so `init` cannot reach a repository-root `templates/`.
They are at `plugins/notation/templates/<tool>/`, referenced through
`${CLAUDE_PLUGIN_ROOT}` — the mechanism the conduct plugin already uses. SPEC
records the constraint.

## Flywheel config provenance

`point-source/flywheel` is not web-indexed (1 star, no docs site), so the
templates were transcribed from the repository itself, not from memory:
`scripts/templates/flywheel-pr.yml`, `scripts/templates/flywheel-push.yml`,
`scripts/templates/flywheel.minimal.yml`, `action.yml`, and
`docs/adopter/setup.md` at `main`. The `v2` annotated tag was independently
dereferenced with `gh api` to commit `59758d1`, which is `v2.1.0`, the latest
stable release.

## Security review — findings fixed in this PR

The templates land verbatim in third-party repos, so the review treated them as
supply chain. Fixed here:

- **SHA-pin `point-source/flywheel`** at `59758d1` (v2.1.0) instead of `@v2`.
  The action receives a GitHub App *private key*, and the setup steps grant that
  App a branch-protection bypass; a floating tag would let its repository
  repoint that credential at new code without review.
- **Same-repo head guard on `auto-merge-release.yml`.** `pull_request_target`
  runs with base-repo secrets, and the label was the only gate — anyone able to
  label a fork PR reached the App token and auto-merged. Fixed in symphonize's
  own workflow (the canonical source), so the template inherits it. Closes the
  fork vector; an insider with write access remains able to self-merge via the
  label, which needs a bot-author check this PR cannot exercise.
- **`permissions: contents: read` on `flywheel-push.yml`.** Upstream ships no
  block, so the job inherited the repository default — write on everything for
  older repos — while flywheel mints its own token anyway.
- **Tag-shape gate on the adopter `update-major-tag.yml`.** Ungated, publishing
  an RC force-moved the stable `v<major>` onto prerelease code, and a tag with
  no dot force-pushed itself.
- **`.github/dependabot.yml` scaffolding**, which §spec:scaffold-freshness
  promised but no command implemented. Adopter copies now self-heal.
- **Documented the `chore` auto-merge consequence.** `init.md` now names the
  *Actions* secret store for the App key and states that also registering it
  with Dependabot is what enables unreviewed dependency merges.

Reviewed twice; the second pass confirmed the folded `if:` scalars parse to the
intended single-line expressions and found no bypass in the tag-shape check.

## Known, deliberately deferred

- `release-please.yml` and `auto-merge-release.yml` carry
  `contents: write` / `pull-requests: write` that nothing uses (all writes go
  through the App token). Tightening to `permissions: {}` risks breaking a
  release pipeline this PR cannot exercise. Pre-existing, rated low.
- `RELEASE_BOT_APP_ID` is stored as a secret; an App ID is not confidential and
  belongs in a variable, as the flywheel templates do it. Changing it needs
  re-provisioning repository settings.

## Verify

`ROADMAP §road:init-release-selection`'s criteria were exercised as a dry-run of
the file mechanics across three scratch repos: flywheel scaffolds `.flywheel.yml`
plus both workflows and no release-please files; release-please scaffolds its
config, manifest, and three workflows and no `.flywheel.yml`; manual scaffolds
neither but keeps `CHANGELOG.md`'s `[Unreleased]`; and each repo's state
re-detects its own tool. Governance-lint (markdownlint, Vale, status lines,
heading grammar) and the fragment-drift check pass locally.

The prompt itself needs a human: run `/notation:init` in a fresh repo, accept
the default, then run it again and confirm it reports
`detected release automation: flywheel` without re-prompting.

> Run /review --comment to post code-quality findings as PR comments.
