### PR TITLE
docs(governance): post-merge cleanup — retire shipped workstream, correct stale statuses

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,20 +1,5 @@
 # symphonize — Roadmap
 
-## Scaffolding freshness §road:scaffolding-freshness
-
-### Scaffold consumer dependabot §road:scaffold-consumer-dependabot
-
-Add a `.github/dependabot.yml` (`github-actions`) to the files
-`/notation:init` scaffolds, and document the scaffold-current-state /
-delegate-freshness contract in `plugins/notation/commands/init.md`.
-§spec:scaffold-freshness
-
-**Verify:** a repo scaffolded by `/notation:init` contains a
-`.github/dependabot.yml` enabling weekly `github-actions` updates;
-`plugins/notation/commands/init.md` and §spec:scaffold-freshness agree on
-the contract; governance-lint passes. The dependabot scaffolding lives with
-the `init` scaffolder, now in `plugins/notation/commands/init.md`.
-
 ## Prose-linting scope alignment §road:prose-linting-scope
 
 ### Align modal-verb guidance with document-wide Vale rule §road:modal-verb-scope

--- a/SPEC.md
+++ b/SPEC.md
@@ -118,7 +118,7 @@ in the governance loop. Scaffolding reduces setup from "read the
 docs and copy-paste" to one command.
 
 ## Reusable CI workflows §spec:reusable-ci
-*Status: in progress*
+*Status: complete*
 
 Now the notation plugin's, under §spec:governance-schema; the workflows stay
 at the repository root `.github/workflows/` (GitHub Actions resolves reusable
@@ -165,7 +165,7 @@ release. In symphonize it is gated to the notation release, moving
 for the reusable `governance-lint.yml`.
 
 ## Scaffolding freshness §spec:scaffold-freshness
-*Status: in progress*
+*Status: complete*
 
 `/notation:init` scaffolds the current state of the world; it does not
 keep scaffolded files current afterward. This matches every scaffolder


### PR DESCRIPTION
Post-merge governance reconciliation after #199 and #200 merged. Docs only.

## Retire `§road:scaffold-consumer-dependabot`

The workstream shipped as a side effect of #199, not as its own batch. #199's
security pass found that §spec:scaffold-freshness promised consumer dependabot
scaffolding that no command implemented, and added it. `init.md` now creates
`.github/dependabot.yml` with a weekly `github-actions` schedule, states the
contract ("the scaffolded workflows are the project's copies to maintain, and
their action pins go stale; Dependabot is what keeps them current"), and adds
only the missing entry when the file already exists.

That satisfies every clause of the workstream's Verify criterion. Its parent
section held no other workstream, so the section goes with it. No other
document referenced the slug.

## Two stale status lines

- **`§spec:scaffold-freshness` → complete.** Its last workstream is the one
  retired above.
- **`§spec:reusable-ci` → complete.** Its templates landed with #199, and
  SPEC.md already records it as superseded by `§spec:governance-schema`,
  `§spec:self-contained-conventions`, `§spec:project-scaffolding`, and
  `§spec:dogfooding` — all four already `complete`. Leaving it `in progress`
  contradicted its own superseders.

`§spec:release-automation-options` stays `in progress`: `§road:clean-release-check`
is still open.

## Not compressed

Both newly-complete sections are already rationale-dense — `scaffold-freshness`
is mostly the "why delegate copy freshness rather than check it" argument, and
`reusable-ci`'s subsections are one-line pointers. Nothing met the compression
heuristic, so the prose is unchanged.

## Verification

Vale 0/0, markdownlint-cli2 0 issues across 7 files, SPEC status-line
validator, heading-addressing grammar validator (48 slugs, no dangling or
duplicate refs), and `assemble-fragments.sh` drift check — all clean.

> Run /review --comment to post code-quality findings as PR comments.
