### PR TITLE
ci: run vale directly; the vale-action reviewdog bridge dies on node 24

### DIFF
--- a/.github/workflows/governance-lint.yml
+++ b/.github/workflows/governance-lint.yml
@@ -17,14 +17,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Run the pinned vale binary directly. vale-cli/vale-action@v3's
+      # reviewdog bridge crashes with EPIPE on the Node 24 runner image
+      # even with zero findings; the binary's exit code is the whole
+      # gate, and linting the tree root reports every finding in the
+      # configured files, so CI matches a local `vale` run.
       - name: Run Vale prose linter
         if: hashFiles('.vale.ini') != ''
-        uses: vale-cli/vale-action@v3
-        with:
-          fail_on_error: true
-          # Report every finding in the linted files, not only lines the
-          # current diff touches, so CI matches a local `vale` run.
-          filter_mode: nofilter
+        env:
+          VALE_VERSION: "3.17.1"
+        run: |
+          curl -sfLo "$RUNNER_TEMP/vale.tar.gz" \
+            "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
+          tar -xzf "$RUNNER_TEMP/vale.tar.gz" -C "$RUNNER_TEMP" vale
+          "$RUNNER_TEMP/vale" --output=line .
 
       - uses: DavidAnson/markdownlint-cli2-action@v24
         with:


### PR DESCRIPTION
vale-cli/vale-action@v3's reviewdog bridge crashes with `write EPIPE` on the Node 24 runner image even when vale reports zero findings (first seen on color-wrangler #11's governance lint; vale itself printed `{}` and exited clean). Same failure class as #195's markdownlint bump — the runner rolled to Node 24 and took the wrapper down.

Replaces the action with a direct pinned-binary invocation: download vale 3.17.1 into $RUNNER_TEMP, run `vale --output=line .` — the exit code is the whole gate, and tree-root scope preserves the nofilter/whole-file behavior the old step configured. Skip-when-no-.vale.ini guard unchanged. Verified locally against color-wrangler and ocio-display-gen configs (exit 0, matching the action's empty JSON).

Deployment note: this touches only the root reusable workflow, so release-please won't attribute it to any package — it reaches adopters when `notation--v0` next moves (any linked release). If nothing is pending, the tag needs a release or a manual advance to unblock downstream governance-lint jobs.