### PR TITLE
fix(governance-lint): treat Development and its kin as orientation

### DIFF
--- a/.github/workflows/governance-lint.yml
+++ b/.github/workflows/governance-lint.yml
@@ -298,7 +298,7 @@ jobs:
 
             # Orientation headings make no claim about the system's design, so
             # they are exempt from the citation probe.
-            orientation='^(#+ )?(install(ation)?|getting started|quick start|usage|api|api reference|licen(se|sing)|licensing note|prerequisites|contributing|acknowledgements?|credits)$'
+            orientation='^(#+ )?(install(ation)?|getting started|quick start|usage|examples?|api|api reference|licen(se|sing)|licensing note|prerequisites|requirements|development|developing|building|build|testing|tests|contributing|support|security|changelog|acknowledgements?|credits|authors?)$'
 
             flush_section() {
               [ -z "$section" ] && return

--- a/SPEC.md
+++ b/SPEC.md
@@ -239,6 +239,12 @@ either orientation, which needs no citation, or an assertion whose home
 is missing. It warns rather than fails because the judgement of which one
 it is belongs to an author, not a linter.
 
+Orientation is a fixed list — install, usage, examples, API, development,
+building, testing, prerequisites, contributing, support, security,
+changelog, licence, credits — because these sections tell a reader how to
+run the thing rather than what it is. A section named for the system's own
+concepts is not orientation, whatever it is called, and cites its source.
+
 *Why not require citations everywhere*: install commands, a usage
 snippet and a licence name are not claims about the system's design, and
 a reference on each would be noise that trains a reader to skip them.


### PR DESCRIPTION
The derivability probe exempts orientation headings from needing a citation, but the list was drawn from this repository's own README and missed the ones its siblings use. A `## Development` section explaining `uv sync && tools/ci.sh` warned that it should cite a governance file, which is advice no author should take.

Found by running the check against two adopters rather than only here: pyst2110 warned on Development, whose whole content is two shell commands.

Widen the list to the sections that tell a reader how to run the thing — examples, development, building, testing, requirements, support, security, changelog, authors — and record in §spec:readme-derivable what makes a heading orientation, so the list reads as a closed category rather than an arbitrary set. A section named for the system's own concepts still cites its source.